### PR TITLE
Start Milestone 3 with platform storage and CLI boundaries

### DIFF
--- a/docs/milestone-m3.md
+++ b/docs/milestone-m3.md
@@ -1,0 +1,87 @@
+# Milestone 3 — Platform boundaries
+
+Status: in progress
+
+## Purpose
+
+Milestone 2 proved the core data-engineering patterns with dependency-light,
+local implementations. Milestone 3 turns those exercises into a small local
+platform without discarding the educational implementations that make the
+repository useful.
+
+The architectural rule for M3 is:
+
+```text
+workflow logic -> platform contracts -> local or infrastructure adapters
+```
+
+Vendor clients must not become the application architecture.
+
+## Phase 1 — storage and command boundaries
+
+The first M3 slice introduces two boundaries that were previously placeholders.
+
+### Unified command surface
+
+Python and JavaScript now expose one top-level command:
+
+```text
+data-platform-lab benchmark ...
+data-platform-lab stream ...
+data-platform-lab warehouse ...
+```
+
+The root command delegates to the existing workflow CLIs. It does not copy
+their argument declarations, so configuration parsing remains owned by each
+workflow until a later configuration-contract refactor is justified.
+
+### Object-storage contract
+
+Both runtimes now implement the same minimal local object-store semantics:
+
+- put bytes by portable relative key;
+- get bytes by key;
+- test object existence;
+- list objects by prefix in deterministic order;
+- reject absolute paths and parent traversal;
+- replace complete objects atomically on the local filesystem.
+
+Python formalises the boundary as a `BlobStore` protocol and provides
+`LocalBlobStore`. JavaScript provides the equivalent `LocalBlobStore` adapter.
+The local implementation is the development and test adapter, not the final
+production storage technology.
+
+## Why infrastructure is not added in this phase
+
+Adding PostgreSQL, an S3-compatible object store, Iceberg, and an event broker
+before defining application boundaries would make pipeline modules depend
+straight on vendor SDKs. That would create a collection of integrations rather
+than a platform.
+
+M3 therefore proceeds in this order:
+
+1. stable storage and command boundaries;
+2. S3-compatible object-store adapter and Docker Compose service;
+3. relational run/metadata store backed by PostgreSQL;
+4. Iceberg analytical tables over object storage;
+5. event-broker adapter for the streaming exercise;
+6. end-to-end local platform demo and failure/recovery tests.
+
+## Non-goals for Phase 1
+
+- replacing the existing medallion filesystem examples;
+- changing the statistical or business semantics of any workflow;
+- introducing distributed execution;
+- treating local filesystem storage as production object storage;
+- duplicating child CLI configuration at the root command.
+
+## Acceptance criteria
+
+Phase 1 is complete when both runtimes have:
+
+- a tested root CLI with benchmark, stream, and warehouse dispatch;
+- a tested local blob-store adapter;
+- traversal-safe object keys;
+- deterministic prefix listing;
+- complete-object replacement semantics;
+- package-level command registration.

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -8,6 +8,9 @@
   "engines": {
     "node": ">=22.0.0"
   },
+  "bin": {
+    "data-platform-lab": "src/cli/main.js"
+  },
   "scripts": {
     "test": "node --test 'tests/*.test.js'",
     "lint": "eslint src/ tests/",

--- a/javascript/src/cli/main.js
+++ b/javascript/src/cli/main.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const COMMANDS = new Map([
+  ["benchmark", new URL("../benchmark/cli.js", import.meta.url)],
+  ["stream", new URL("../streaming/cli.js", import.meta.url)],
+  ["warehouse", new URL("../warehouse/cli.js", import.meta.url)],
+]);
+
+/** @returns {string} */
+export function helpText() {
+  return `Usage: data-platform-lab <command> [arguments]\n\nCommands:\n  benchmark   Run ingestion benchmarks\n  stream      Process streaming sensor events\n  warehouse   Run the warehouse pipeline`;
+}
+
+/**
+ * Resolve one platform command into a Node child process invocation.
+ * @param {string[]} argv
+ * @returns {{script: string, args: string[]} | null}
+ */
+export function resolveCommand(argv) {
+  if (!Array.isArray(argv)) {
+    throw new TypeError("argv must be an array");
+  }
+  if (argv.length === 0) return null;
+
+  const [command, ...args] = argv;
+  const target = COMMANDS.get(command);
+  if (!target) {
+    throw new Error(`Unknown command: ${command}`);
+  }
+  return { script: fileURLToPath(target), args };
+}
+
+/** @param {string[]} [argv=process.argv.slice(2)] */
+export function main(argv = process.argv.slice(2)) {
+  const resolved = resolveCommand(argv);
+  if (!resolved) {
+    console.log(helpText());
+    return 0;
+  }
+
+  const result = spawnSync(process.execPath, [resolved.script, ...resolved.args], {
+    stdio: "inherit",
+  });
+  if (result.error) throw result.error;
+  return result.status ?? 1;
+}
+
+const isDirect = process.argv[1]
+  ? import.meta.url === pathToFileURL(process.argv[1]).href
+  : false;
+
+if (isDirect) {
+  process.exitCode = main();
+}

--- a/javascript/src/storage/index.js
+++ b/javascript/src/storage/index.js
@@ -1,6 +1,7 @@
-/**
- * Storage — write data to layered storage with format and partition control.
- *
- * Covers medallion-layer writes (raw, bronze, silver, gold), file format
- * selection (CSV, JSON), partitioning strategies, and manifest tracking.
- */
+/** Storage contracts and local adapters for platform workflows. */
+
+export {
+  LocalBlobStore,
+  StorageKeyError,
+  normalizeKey,
+} from "./local-store.js";

--- a/javascript/src/storage/local-store.js
+++ b/javascript/src/storage/local-store.js
@@ -1,0 +1,137 @@
+import { mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+
+/** Error raised when an object key is unsafe or invalid. */
+export class StorageKeyError extends Error {
+  /** @param {string} message */
+  constructor(message) {
+    super(message);
+    this.name = "StorageKeyError";
+  }
+}
+
+/**
+ * Validate and normalize a portable object key.
+ * @param {string} key
+ * @returns {string}
+ */
+export function normalizeKey(key) {
+  if (typeof key !== "string") {
+    throw new TypeError("key must be a string");
+  }
+
+  const candidate = key.trim().replaceAll("\\", "/");
+  const parts = candidate.split("/");
+
+  if (!candidate || candidate === "." || candidate === "/") {
+    throw new StorageKeyError("key must not be empty");
+  }
+  if (candidate.startsWith("/")) {
+    throw new StorageKeyError("key must be relative");
+  }
+  if (parts.some((part) => part === "" || part === "." || part === "..")) {
+    throw new StorageKeyError("key must not contain traversal components");
+  }
+
+  return parts.join("/");
+}
+
+/** Filesystem-backed object store for local development and tests. */
+export class LocalBlobStore {
+  /** @param {string} root */
+  constructor(root) {
+    if (typeof root !== "string") {
+      throw new TypeError("root must be a string");
+    }
+    this.root = resolve(root);
+    mkdirSync(this.root, { recursive: true });
+  }
+
+  /**
+   * Resolve a validated key below the storage root.
+   * @param {string} key
+   * @returns {string}
+   */
+  _resolveKey(key) {
+    const normalized = normalizeKey(key);
+    const target = resolve(this.root, ...normalized.split("/"));
+    const rel = relative(this.root, target);
+
+    if (rel.startsWith(`..${sep}`) || rel === "..") {
+      throw new StorageKeyError("key resolves outside storage root");
+    }
+    return target;
+  }
+
+  /**
+   * Persist a buffer atomically under a key.
+   * @param {string} key
+   * @param {Buffer} payload
+   * @returns {{key: string, size_bytes: number}}
+   */
+  putBytes(key, payload) {
+    if (!Buffer.isBuffer(payload)) {
+      throw new TypeError("payload must be a Buffer");
+    }
+
+    const normalized = normalizeKey(key);
+    const target = this._resolveKey(normalized);
+    mkdirSync(dirname(target), { recursive: true });
+
+    const temporary = join(dirname(target), `.${target.split(sep).at(-1)}.tmp`);
+    writeFileSync(temporary, payload);
+    renameSync(temporary, target);
+
+    return { key: normalized, size_bytes: payload.length };
+  }
+
+  /** @param {string} key @returns {Buffer} */
+  getBytes(key) {
+    return readFileSync(this._resolveKey(key));
+  }
+
+  /** @param {string} key @returns {boolean} */
+  exists(key) {
+    try {
+      return statSync(this._resolveKey(key)).isFile();
+    } catch (error) {
+      if (error && typeof error === "object" && "code" in error && error.code === "ENOENT") {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * List objects in deterministic key order.
+   * @param {string} [prefix=""]
+   * @returns {Promise<Array<{key: string, size_bytes: number}>>}
+   */
+  async listObjects(prefix = "") {
+    if (typeof prefix !== "string") {
+      throw new TypeError("prefix must be a string");
+    }
+    const normalizedPrefix = prefix.trim() ? normalizeKey(prefix) : "";
+    const objects = [];
+
+    /** @param {string} directory */
+    const visit = async (directory) => {
+      const entries = await readdir(directory, { withFileTypes: true });
+      for (const entry of entries) {
+        const path = join(directory, entry.name);
+        if (entry.isDirectory()) {
+          await visit(path);
+        } else if (entry.isFile()) {
+          const key = relative(this.root, path).split(sep).join("/");
+          if (!normalizedPrefix || key.startsWith(normalizedPrefix)) {
+            objects.push({ key, size_bytes: statSync(path).size });
+          }
+        }
+      }
+    };
+
+    await visit(this.root);
+    return objects.sort((left, right) => left.key.localeCompare(right.key));
+  }
+}

--- a/javascript/tests/cli-main.test.js
+++ b/javascript/tests/cli-main.test.js
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { helpText, resolveCommand } from "../src/cli/main.js";
+
+test("helpText exposes all unified commands", () => {
+  const help = helpText();
+  assert.match(help, /benchmark/);
+  assert.match(help, /stream/);
+  assert.match(help, /warehouse/);
+});
+
+test("resolveCommand forwards child arguments unchanged", () => {
+  const resolved = resolveCommand([
+    "stream",
+    "--input",
+    "events.jsonl",
+    "--output-dir",
+    "out",
+  ]);
+
+  assert.ok(resolved);
+  assert.match(resolved.script, /streaming[\\/]cli\.js$/);
+  assert.deepEqual(resolved.args, [
+    "--input",
+    "events.jsonl",
+    "--output-dir",
+    "out",
+  ]);
+});
+
+test("resolveCommand rejects unknown commands", () => {
+  assert.throws(() => resolveCommand(["missing"]), /Unknown command/);
+});

--- a/javascript/tests/storage-local.test.js
+++ b/javascript/tests/storage-local.test.js
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  LocalBlobStore,
+  StorageKeyError,
+  normalizeKey,
+} from "../src/storage/index.js";
+
+test("normalizeKey rejects traversal", () => {
+  assert.throws(() => normalizeKey("../outside.txt"), StorageKeyError);
+});
+
+test("normalizeKey converts backslashes", () => {
+  assert.equal(
+    normalizeKey("silver\\orders\\part-000.csv"),
+    "silver/orders/part-000.csv",
+  );
+});
+
+test("LocalBlobStore implements put, get, exists, and list", async (t) => {
+  const root = mkdtempSync(join(tmpdir(), "data-platform-lab-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const store = new LocalBlobStore(root);
+
+  const first = store.putBytes("bronze/events/part-001.jsonl", Buffer.from("one\n"));
+  store.putBytes("bronze/events/part-002.jsonl", Buffer.from("two\n"));
+  store.putBytes("silver/events.csv", Buffer.from("id\n1\n"));
+
+  assert.equal(first.size_bytes, 4);
+  assert.equal(store.exists(first.key), true);
+  assert.equal(store.getBytes(first.key).toString("utf8"), "one\n");
+  assert.deepEqual(
+    (await store.listObjects("bronze/events")).map((item) => item.key),
+    ["bronze/events/part-001.jsonl", "bronze/events/part-002.jsonl"],
+  );
+});
+
+test("LocalBlobStore replaces a complete object", (t) => {
+  const root = mkdtempSync(join(tmpdir(), "data-platform-lab-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const store = new LocalBlobStore(root);
+
+  store.putBytes("gold/report.json", Buffer.from("old"));
+  const stored = store.putBytes("gold/report.json", Buffer.from("new-value"));
+
+  assert.equal(stored.size_bytes, 9);
+  assert.equal(store.getBytes("gold/report.json").toString("utf8"), "new-value");
+});

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -15,6 +15,9 @@ pytest = ">=8.0"
 ruff = ">=0.4"
 mypy = ">=1.10"
 
+[tool.poetry.scripts]
+data-platform-lab = "data_platform_lab.cli.main:main"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/python/src/data_platform_lab/cli/main.py
+++ b/python/src/data_platform_lab/cli/main.py
@@ -1,0 +1,55 @@
+"""Unified command-line entry point for Data Platform Lab."""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from data_platform_lab.benchmark.cli import main as benchmark_main
+from data_platform_lab.streaming.cli import main as streaming_main
+from data_platform_lab.warehouse.cli import main as warehouse_main
+
+CommandHandler = Callable[[list[str] | None], None]
+
+_COMMANDS: dict[str, CommandHandler] = {
+    "benchmark": benchmark_main,
+    "stream": streaming_main,
+    "warehouse": warehouse_main,
+}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the top-level parser without duplicating child command options."""
+    parser = argparse.ArgumentParser(
+        prog="data-platform-lab",
+        description="Unified entry point for Data Platform Lab workflows.",
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=sorted(_COMMANDS),
+        help="Workflow to run. Remaining arguments are passed to that workflow.",
+    )
+    parser.add_argument(
+        "arguments",
+        nargs=argparse.REMAINDER,
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Dispatch to a workflow CLI while preserving its existing arguments."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        return
+
+    handler = _COMMANDS[args.command]
+    handler(args.arguments)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/data_platform_lab/storage/__init__.py
+++ b/python/src/data_platform_lab/storage/__init__.py
@@ -1,5 +1,17 @@
-"""Storage — write data to layered storage with partitioning and format control.
+"""Storage contracts and local adapters for platform workflows."""
 
-Covers medallion-layer writes (raw, bronze, silver, gold), file format
-selection (CSV, JSON, Parquet), partitioning strategies, and manifest tracking.
-"""
+from data_platform_lab.storage.local import (
+    BlobStore,
+    LocalBlobStore,
+    StorageKeyError,
+    StoredObject,
+    normalize_key,
+)
+
+__all__ = [
+    "BlobStore",
+    "LocalBlobStore",
+    "StorageKeyError",
+    "StoredObject",
+    "normalize_key",
+]

--- a/python/src/data_platform_lab/storage/local.py
+++ b/python/src/data_platform_lab/storage/local.py
@@ -1,0 +1,128 @@
+"""Local filesystem implementation of the platform object-store boundary."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Protocol, runtime_checkable
+
+
+class StorageKeyError(ValueError):
+    """Raised when a storage key is unsafe or invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class StoredObject:
+    """Metadata for one object stored by a :class:`BlobStore`."""
+
+    key: str
+    size_bytes: int
+
+
+@runtime_checkable
+class BlobStore(Protocol):
+    """Minimal object-storage contract used by platform workflows."""
+
+    def put_bytes(self, key: str, payload: bytes) -> StoredObject:
+        """Persist *payload* under *key* and return object metadata."""
+
+    def get_bytes(self, key: str) -> bytes:
+        """Return the bytes stored under *key*."""
+
+    def exists(self, key: str) -> bool:
+        """Return whether *key* exists."""
+
+    def list_objects(self, prefix: str = "") -> list[StoredObject]:
+        """List stored objects below *prefix* in deterministic key order."""
+
+
+def normalize_key(key: str) -> str:
+    """Validate and normalize a portable object key.
+
+    Keys are POSIX-style relative paths. Absolute paths, empty paths, current
+    directory markers, and parent traversal are rejected so callers cannot
+    escape the configured storage root.
+    """
+    if not isinstance(key, str):
+        raise TypeError("key must be a string")
+
+    candidate = key.strip().replace("\\", "/")
+    path = PurePosixPath(candidate)
+
+    if not candidate or candidate in {".", "/"}:
+        raise StorageKeyError("key must not be empty")
+    if path.is_absolute():
+        raise StorageKeyError("key must be relative")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise StorageKeyError("key must not contain traversal components")
+
+    return path.as_posix()
+
+
+class LocalBlobStore:
+    """Filesystem-backed :class:`BlobStore` for local development and tests."""
+
+    def __init__(self, root: str | Path) -> None:
+        """Create a store rooted at *root*, creating the directory if needed."""
+        if not isinstance(root, (str, Path)):
+            raise TypeError("root must be a string or Path")
+
+        self._root = Path(root).expanduser().resolve()
+        self._root.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def root(self) -> Path:
+        """Return the resolved storage root."""
+        return self._root
+
+    def _resolve(self, key: str) -> Path:
+        """Resolve *key* below the store root after validating it."""
+        normalized = normalize_key(key)
+        target = (self._root / normalized).resolve()
+
+        if target != self._root and self._root not in target.parents:
+            raise StorageKeyError("key resolves outside storage root")
+        return target
+
+    def put_bytes(self, key: str, payload: bytes) -> StoredObject:
+        """Persist bytes atomically under *key*."""
+        if not isinstance(payload, bytes):
+            raise TypeError("payload must be bytes")
+
+        normalized = normalize_key(key)
+        target = self._resolve(normalized)
+        target.parent.mkdir(parents=True, exist_ok=True)
+
+        temporary = target.with_name(f".{target.name}.tmp")
+        temporary.write_bytes(payload)
+        temporary.replace(target)
+
+        return StoredObject(key=normalized, size_bytes=len(payload))
+
+    def get_bytes(self, key: str) -> bytes:
+        """Read bytes stored under *key*."""
+        return self._resolve(key).read_bytes()
+
+    def exists(self, key: str) -> bool:
+        """Return whether *key* exists as a regular file."""
+        return self._resolve(key).is_file()
+
+    def list_objects(self, prefix: str = "") -> list[StoredObject]:
+        """List all objects whose keys start with *prefix*."""
+        if not isinstance(prefix, str):
+            raise TypeError("prefix must be a string")
+
+        normalized_prefix = ""
+        if prefix.strip():
+            normalized_prefix = normalize_key(prefix)
+
+        objects: list[StoredObject] = []
+        for path in self._root.rglob("*"):
+            if not path.is_file():
+                continue
+            key = path.relative_to(self._root).as_posix()
+            if normalized_prefix and not key.startswith(normalized_prefix):
+                continue
+            objects.append(StoredObject(key=key, size_bytes=path.stat().st_size))
+
+        return sorted(objects, key=lambda item: item.key)

--- a/python/tests/test_cli_main.py
+++ b/python/tests/test_cli_main.py
@@ -1,0 +1,30 @@
+"""Tests for the unified Python CLI dispatcher."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from data_platform_lab.cli import main as cli_main_module
+
+
+def test_main_without_command_prints_help(capsys: object) -> None:
+    """Calling the root CLI without a command shows discoverable help."""
+    cli_main_module.main([])
+    captured = capsys.readouterr()  # type: ignore[attr-defined]
+
+    assert "Unified entry point" in captured.out
+    assert "benchmark" in captured.out
+    assert "stream" in captured.out
+    assert "warehouse" in captured.out
+
+
+def test_main_dispatches_remaining_arguments() -> None:
+    """Child workflow arguments are forwarded unchanged."""
+    handler = Mock()
+
+    with patch.dict(cli_main_module._COMMANDS, {"stream": handler}, clear=True):
+        cli_main_module.main(["stream", "--input", "events.jsonl", "--output-dir", "out"])
+
+    handler.assert_called_once_with(
+        ["--input", "events.jsonl", "--output-dir", "out"],
+    )

--- a/python/tests/test_storage_local.py
+++ b/python/tests/test_storage_local.py
@@ -1,0 +1,49 @@
+"""Tests for the local object-store adapter."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from data_platform_lab.storage import LocalBlobStore, StorageKeyError, normalize_key
+
+
+def test_normalize_key_rejects_traversal() -> None:
+    """Parent traversal must never be accepted as an object key."""
+    with pytest.raises(StorageKeyError):
+        normalize_key("../outside.txt")
+
+
+def test_normalize_key_converts_backslashes() -> None:
+    """Object keys remain portable across operating systems."""
+    assert normalize_key(r"silver\orders\part-000.csv") == "silver/orders/part-000.csv"
+
+
+def test_put_get_exists_and_list(tmp_path: Path) -> None:
+    """The local store implements the complete minimal BlobStore contract."""
+    store = LocalBlobStore(tmp_path / "objects")
+
+    first = store.put_bytes("bronze/events/part-001.jsonl", b"one\n")
+    second = store.put_bytes("bronze/events/part-002.jsonl", b"two\n")
+    store.put_bytes("silver/events.csv", b"id\n1\n")
+
+    assert first.size_bytes == 4
+    assert second.key == "bronze/events/part-002.jsonl"
+    assert store.exists(first.key)
+    assert store.get_bytes(first.key) == b"one\n"
+    assert [item.key for item in store.list_objects("bronze/events")] == [
+        "bronze/events/part-001.jsonl",
+        "bronze/events/part-002.jsonl",
+    ]
+
+
+def test_put_bytes_overwrites_atomically(tmp_path: Path) -> None:
+    """Writing an existing key replaces its complete contents."""
+    store = LocalBlobStore(tmp_path)
+    store.put_bytes("gold/report.json", b"old")
+    stored = store.put_bytes("gold/report.json", b"new-value")
+
+    assert stored.size_bytes == 9
+    assert store.get_bytes("gold/report.json") == b"new-value"
+    assert not (tmp_path / "gold" / ".report.json.tmp").exists()


### PR DESCRIPTION
## Summary

Starts Milestone 3 by replacing two placeholder areas with stable platform boundaries before adding vendor infrastructure.

- adds a typed Python `BlobStore` protocol and traversal-safe `LocalBlobStore`
- adds equivalent JavaScript local object-store semantics
- adds one top-level `data-platform-lab` CLI in both runtimes
- delegates root commands to the existing benchmark, streaming, and warehouse CLIs
- registers package-level commands for Poetry and Node
- adds regression tests for storage safety, deterministic listing, complete-object replacement, and CLI dispatch
- documents the M3 ordering: contracts first, then S3-compatible storage, PostgreSQL metadata, Iceberg, and event-broker adapters

## Why this slice first

The repository already had empty `storage/` and `cli/` placeholders. Adding PostgreSQL, MinIO/S3, Iceberg, or a broker directly into workflow modules would couple application logic to vendor clients. This PR creates the seams those infrastructure adapters can implement next.

## Scope

No existing workflow semantics are changed. The current dependency-light exercises remain intact and become the local/reference implementations behind the platform evolution.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the empty `storage/` and `cli/` placeholders with stable platform boundaries so the upcoming S3, PostgreSQL, Iceberg, and event-broker adapters can plug in without coupling workflow logic to vendor SDKs. Adds a `data-platform-lab` command and a local object-store contract in both Python and JavaScript; no existing workflow behavior changes.

**Details**
- The root CLI forwards `benchmark`, `stream`, and `warehouse` arguments unchanged to the existing child CLIs and registers through Poetry scripts and the npm `bin` entry.
- Object keys reject absolute paths and parent traversal; writes replace a complete object atomically, and prefix listings sort deterministically.
- Python formalizes the boundary as a typed `BlobStore` protocol for infrastructure adapters to implement, while JavaScript provides the equivalent `LocalBlobStore`.
- Regression tests cover storage safety, deterministic listing, complete-object replacement, and CLI dispatch.
- `docs/milestone-m3.md` defines the phase ordering: contracts first, then S3-compatible storage, PostgreSQL metadata, Iceberg tables, and event-broker adapters.

<sup>Written for commit 56731ce1795864f62737b72091a69b1fbcbe9669. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/data-platform-lab/pull/34?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

