### PR TITLE
Add PostgreSQL run metadata store

### DIFF
--- a/.github/workflows/postgres-integration.yml
+++ b/.github/workflows/postgres-integration.yml
@@ -1,0 +1,46 @@
+name: PostgreSQL Integration
+
+on:
+  push:
+    paths:
+      - "compose.yaml"
+      - "sql/platform/**"
+      - "python/pyproject.toml"
+      - "python/src/data_platform_lab/metadata/**"
+      - "python/src/data_platform_lab/cli/main.py"
+      - ".github/workflows/postgres-integration.yml"
+  pull_request:
+    paths:
+      - "compose.yaml"
+      - "sql/platform/**"
+      - "python/pyproject.toml"
+      - "python/src/data_platform_lab/metadata/**"
+      - "python/src/data_platform_lab/cli/main.py"
+      - ".github/workflows/postgres-integration.yml"
+
+jobs:
+  postgres:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Start PostgreSQL
+        run: docker compose up -d --wait postgres
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install Poetry
+        run: pipx install poetry
+      - name: Install Python dependencies
+        working-directory: python
+        run: poetry install --no-interaction
+      - name: Run metadata smoke
+        working-directory: python
+        run: poetry run data-platform-lab metadata
+      - name: Inspect persisted run
+        run: docker compose exec -T postgres psql -U data_platform_lab -d data_platform_lab -c "TABLE pipeline_runs;"
+      - name: Diagnostics
+        if: failure()
+        run: docker compose logs postgres
+      - name: Stop services
+        if: always()
+        run: docker compose down -v

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,6 +17,25 @@ services:
       - garage-meta:/var/lib/garage/meta
       - garage-data:/var/lib/garage/data
 
+  postgres:
+    image: postgres:18.6
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: data_platform_lab
+      POSTGRES_USER: data_platform_lab
+      POSTGRES_PASSWORD: data_platform_lab
+    ports:
+      - "127.0.0.1:5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql
+      - ./sql/platform/001_pipeline_runs.sql:/docker-entrypoint-initdb.d/001_pipeline_runs.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U data_platform_lab -d data_platform_lab"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
 volumes:
   garage-meta:
   garage-data:
+  postgres-data:

--- a/docs/milestone-m3.md
+++ b/docs/milestone-m3.md
@@ -2,166 +2,36 @@
 
 Status: in progress
 
-## Purpose
-
-Milestone 2 proved the core data-engineering patterns with dependency-light,
-local implementations. Milestone 3 turns those exercises into a small local
-platform without discarding the educational implementations that make the
-repository useful.
-
-The architectural rule for M3 is:
+## Architectural rule
 
 ```text
 workflow logic -> platform contracts -> local or infrastructure adapters
 ```
 
-Vendor clients must not become the application architecture.
-
-## Platform architecture
+## Current platform architecture
 
 ```mermaid
 flowchart LR
-    subgraph Runtime[Application runtimes]
-        PY[Python CLI / workflows]
-        JS[JavaScript CLI / workflows]
-    end
-
-    PY --> Contract[BlobStore semantics]
-    JS --> Contract
-
-    Contract --> Local[LocalBlobStore]
-    Contract --> S3[S3BlobStore]
-
-    Local --> FS[(Local filesystem)]
-    S3 --> API[S3-compatible API]
-    API --> Garage[(Garage local stack)]
-    API -. endpoint portability .-> Remote[(AWS S3 / compatible service)]
-
-    Garage --> Meta[(Garage metadata volume)]
-    Garage --> Data[(Garage data volume)]
+    PY[Python workflows] --> B[BlobStore]
+    JS[JavaScript workflows] --> B
+    PY --> R[RunStore]
+    JS --> R
+    B --> Local[LocalBlobStore]
+    B --> S3[S3BlobStore]
+    S3 --> Garage[(Garage S3)]
+    R --> PG[PostgresRunStore]
+    PG --> DB[(PostgreSQL 18.6)]
 ```
 
-The contract is the architectural seam. Local and remote storage are adapter
-choices below workflow logic, not separate workflow implementations.
+## Sequence
 
-## Phase 1 — storage and command boundaries
-
-Phase 1 replaced two placeholder areas with stable application boundaries.
-
-### Unified command surface
-
-Python and JavaScript expose one top-level command:
-
-```text
-data-platform-lab benchmark ...
-data-platform-lab storage ...
-data-platform-lab stream ...
-data-platform-lab warehouse ...
-```
-
-The root command delegates to the workflow CLIs. It does not copy their
-argument declarations, so configuration parsing remains owned by each workflow.
-
-### Object-storage contract
-
-Both runtimes implement the same minimal object-store semantics:
-
-- put bytes by portable relative key;
-- get bytes by key;
-- test object existence;
-- list objects by prefix in deterministic order;
-- reject absolute paths and parent traversal;
-- replace complete objects rather than mutating partial file contents.
-
-Python formalises the boundary as a `BlobStore` protocol. `LocalBlobStore` is
-the local reference adapter.
-
-## Phase 2 — S3-compatible object storage
-
-Phase 2 adds infrastructure without changing the storage contract.
-
-### S3 adapters
-
-Python provides `S3BlobStore`, backed by the official boto3 S3 client.
-JavaScript provides `S3BlobStore` plus an AWS SDK v3 client factory. Both
-adapters support:
-
-- custom S3 endpoints;
-- AWS Signature V4;
-- path-style addressing for local S3-compatible services;
-- a configurable bucket namespace prefix;
-- paginated `ListObjectsV2` results;
-- correct separation between a missing object and an authorization/service
-  failure.
-
-The adapters are endpoint-agnostic. The same application boundary can target
-Garage locally, AWS S3, or another compatible service.
-
-### Local S3 service
-
-The Compose stack uses Garage for the local S3 endpoint. Garage is not an
-application dependency; it is one implementation of the S3 protocol used for
-local development and integration testing.
-
-The local service is pinned to `dxflrs/garage:v2.3.0`. Garage v2.3.0 runs
-with its native `--single-node --default-bucket` mode. The Compose service
-supplies deterministic development-only credentials and the `data-platform-lab`
-bucket, while the bootstrap script only starts the service and waits for the
-S3 node to become healthy.
-
-See [S3-compatible local storage](s3-object-storage.md) for commands and the
-security boundary around the committed development credentials.
-
-### Wire-level integration gate
-
-Mocked unit tests exercise pagination, namespace mapping, object round trips,
-and S3 error classification. A separate GitHub Actions workflow then validates
-the real endpoint path:
-
-```mermaid
-flowchart LR
-    CI[GitHub Actions] --> Boot[Start Garage]
-    Boot --> P[Python storage smoke]
-    P --> Boto[boto3]
-    Boto --> S3[S3 API]
-    S3 --> G[(Garage)]
-    G --> J[JavaScript storage smoke]
-    J --> SDK[AWS SDK v3]
-    SDK --> S3
-
-    P -. verifies .-> Checks[put / get / exists / list]
-    J -. verifies .-> Checks
-```
-
-This prevents a useful distinction from being lost: an adapter can satisfy its
-unit-test double and still be wrong on the actual S3 wire protocol.
-
-## M3 sequence
-
-1. stable storage and command boundaries — complete;
-2. S3-compatible object-store adapter and Docker Compose service — complete;
-3. relational run/metadata store backed by PostgreSQL;
+1. storage and unified-command boundaries — complete;
+2. S3-compatible storage and Garage integration — complete;
+3. PostgreSQL-backed run/metadata store — in progress;
 4. Iceberg analytical tables over object storage;
-5. event-broker adapter for the streaming exercise;
-6. end-to-end local platform demo and failure/recovery tests.
+5. event-broker adapter for streaming;
+6. end-to-end platform failure/recovery demo.
 
-## Non-goals so far
+Phase 3 reuses the existing observability `RunMetadata` shape. The initial database contains one deliberately narrow `pipeline_runs` table, keyed by `(pipeline_name, run_id)` and updated idempotently as a run moves from running to success/failed.
 
-- replacing the existing medallion filesystem examples;
-- changing the statistical or business semantics of any workflow;
-- introducing distributed execution;
-- treating a single-node local object store as a production deployment;
-- tying workflow modules directly to boto3, the AWS SDK, or Garage;
-- duplicating child CLI configuration at the root command.
-
-## Phase 2 acceptance criteria
-
-Phase 2 is complete when:
-
-- both runtimes implement the S3 storage semantics behind the existing
-  boundary;
-- custom endpoints and namespace prefixes are tested;
-- paginated object listings are covered by unit tests;
-- missing-object checks do not swallow authorization failures;
-- the local S3 service is reproducible from Compose plus one bootstrap command;
-- Python and JavaScript both pass a live S3 round-trip smoke test in CI.
+See [PostgreSQL run metadata](postgres-run-metadata.md) for the ER diagram, persistence contract, and local validation flow.

--- a/docs/postgres-run-metadata.md
+++ b/docs/postgres-run-metadata.md
@@ -1,0 +1,61 @@
+# PostgreSQL run metadata
+
+Milestone 3 Phase 3 makes pipeline run history durable without changing the existing `RunMetadata` model.
+
+## Data model
+
+```mermaid
+erDiagram
+    PIPELINE_RUNS {
+        text pipeline_name PK
+        text run_id PK
+        text status
+        timestamptz started_at
+        timestamptz ended_at
+        double duration_seconds
+        bigint rows_read
+        bigint rows_written
+        bigint rows_rejected
+        bigint files_processed
+        bigint files_rejected
+        jsonb warnings
+        jsonb errors
+        jsonb extra
+        timestamptz recorded_at
+        timestamptz updated_at
+    }
+```
+
+The compound key `(pipeline_name, run_id)` makes snapshots idempotent: a running record can be updated when the same run finishes.
+
+## Platform topology
+
+```mermaid
+flowchart LR
+    PY[Python workflows] --> RM[RunMetadata]
+    JS[JavaScript workflows] --> RM
+    RM --> RS[RunStore contract]
+    RS --> PG[PostgresRunStore]
+    PG --> DB[(PostgreSQL 18.6)]
+    DB --> History[Durable run history]
+    Workflows[Existing manifests] -. complementary .-> RM
+```
+
+Python provides the live PostgreSQL factory through psycopg and the wire-level CI smoke test. JavaScript implements the same SQL/run-store semantics against an injected `query()` client; a locked JavaScript PostgreSQL driver factory is deliberately deferred rather than weakening Yarn reproducibility.
+
+## Local use
+
+```bash
+docker compose up -d --wait postgres
+cd python
+poetry install
+poetry run data-platform-lab metadata
+```
+
+Default local DSN:
+
+```text
+postgresql://data_platform_lab:data_platform_lab@localhost:5432/data_platform_lab
+```
+
+The credentials are for the disposable local Compose stack only.

--- a/javascript/src/metadata/index.js
+++ b/javascript/src/metadata/index.js
@@ -1,0 +1,1 @@
+export { PostgresRunStore } from "./postgres-store.js";

--- a/javascript/src/metadata/postgres-store.js
+++ b/javascript/src/metadata/postgres-store.js
@@ -1,0 +1,41 @@
+const COLUMNS = [
+  "pipeline_name", "run_id", "status", "started_at", "ended_at", "duration_seconds",
+  "rows_read", "rows_written", "rows_rejected", "files_processed", "files_rejected",
+  "warnings", "errors", "extra",
+];
+
+export class PostgresRunStore {
+  constructor(client) {
+    if (!client || typeof client.query !== "function") throw new TypeError("client must implement query()");
+    this.client = client;
+  }
+
+  async save(metadata) {
+    const text = `INSERT INTO pipeline_runs (${COLUMNS.join(",")})
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12::jsonb,$13::jsonb,$14::jsonb)
+      ON CONFLICT (pipeline_name,run_id) DO UPDATE SET
+      status=EXCLUDED.status, started_at=EXCLUDED.started_at, ended_at=EXCLUDED.ended_at,
+      duration_seconds=EXCLUDED.duration_seconds, rows_read=EXCLUDED.rows_read,
+      rows_written=EXCLUDED.rows_written, rows_rejected=EXCLUDED.rows_rejected,
+      files_processed=EXCLUDED.files_processed, files_rejected=EXCLUDED.files_rejected,
+      warnings=EXCLUDED.warnings, errors=EXCLUDED.errors, extra=EXCLUDED.extra, updated_at=now()`;
+    const values = [
+      metadata.pipeline_name, metadata.run_id, metadata.status, metadata.started_at,
+      metadata.ended_at, metadata.duration_seconds, metadata.rows_read, metadata.rows_written,
+      metadata.rows_rejected, metadata.files_processed, metadata.files_rejected,
+      JSON.stringify(metadata.warnings), JSON.stringify(metadata.errors), JSON.stringify(metadata.extra),
+    ];
+    await this.client.query(text, values);
+  }
+
+  async get(pipelineName, runId) {
+    const result = await this.client.query(`SELECT ${COLUMNS.join(",")} FROM pipeline_runs WHERE pipeline_name=$1 AND run_id=$2`, [pipelineName, runId]);
+    return result.rows?.[0] ?? null;
+  }
+
+  async listRecent(limit = 20) {
+    if (!Number.isInteger(limit) || limit < 1) throw new TypeError("limit must be a positive integer");
+    const result = await this.client.query(`SELECT ${COLUMNS.join(",")} FROM pipeline_runs ORDER BY started_at DESC NULLS LAST, recorded_at DESC LIMIT $1`, [limit]);
+    return result.rows ?? [];
+  }
+}

--- a/javascript/tests/metadata-postgres.test.js
+++ b/javascript/tests/metadata-postgres.test.js
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { PostgresRunStore } from "../src/metadata/index.js";
+
+class FakeClient {
+  constructor() { this.calls = []; this.rows = []; }
+  async query(text, values) {
+    this.calls.push({ text, values });
+    if (text.startsWith("SELECT")) return { rows: this.rows };
+    return { rows: [] };
+  }
+}
+
+const metadata = {
+  pipeline_name: "demo", run_id: "r1", status: "success",
+  started_at: "2026-09-01T00:00:00Z", ended_at: "2026-09-01T00:00:01Z",
+  duration_seconds: 1, rows_read: 10, rows_written: 9, rows_rejected: 1,
+  files_processed: 1, files_rejected: 0, warnings: [], errors: [], extra: { source: "test" },
+};
+
+test("PostgresRunStore upserts the shared run metadata shape", async () => {
+  const client = new FakeClient();
+  await new PostgresRunStore(client).save(metadata);
+  assert.match(client.calls[0].text, /ON CONFLICT/);
+  assert.equal(client.calls[0].values[0], "demo");
+  assert.equal(client.calls[0].values[13], JSON.stringify({ source: "test" }));
+});
+
+test("PostgresRunStore reads and lists rows through injected client", async () => {
+  const client = new FakeClient();
+  client.rows = [metadata];
+  const store = new PostgresRunStore(client);
+  assert.deepEqual(await store.get("demo", "r1"), metadata);
+  assert.deepEqual(await store.listRecent(5), [metadata]);
+});

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{ include = "data_platform_lab", from = "src" }]
 [tool.poetry.dependencies]
 python = ">=3.11"
 boto3 = ">=1.40,<2.0"
+psycopg = {version = ">=3.2,<4.0", extras = ["binary"]}
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0"

--- a/python/src/data_platform_lab/cli/main.py
+++ b/python/src/data_platform_lab/cli/main.py
@@ -6,6 +6,7 @@ import argparse
 from collections.abc import Callable
 
 from data_platform_lab.benchmark.cli import main as benchmark_main
+from data_platform_lab.metadata.cli import main as metadata_main
 from data_platform_lab.storage.cli import main as storage_main
 from data_platform_lab.streaming.cli import main as streaming_main
 from data_platform_lab.warehouse.cli import main as warehouse_main
@@ -14,6 +15,7 @@ CommandHandler = Callable[[list[str] | None], None]
 
 _COMMANDS: dict[str, CommandHandler] = {
     "benchmark": benchmark_main,
+    "metadata": metadata_main,
     "storage": storage_main,
     "stream": streaming_main,
     "warehouse": warehouse_main,
@@ -21,36 +23,17 @@ _COMMANDS: dict[str, CommandHandler] = {
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    """Build the top-level parser without duplicating child command options."""
-    parser = argparse.ArgumentParser(
-        prog="data-platform-lab",
-        description="Unified entry point for Data Platform Lab workflows.",
-    )
-    parser.add_argument(
-        "command",
-        nargs="?",
-        choices=sorted(_COMMANDS),
-        help="Workflow to run. Remaining arguments are passed to that workflow.",
-    )
-    parser.add_argument(
-        "arguments",
-        nargs=argparse.REMAINDER,
-        help=argparse.SUPPRESS,
-    )
+    parser = argparse.ArgumentParser(prog="data-platform-lab", description="Unified entry point for Data Platform Lab workflows.")
+    parser.add_argument("command", nargs="?", choices=sorted(_COMMANDS), help="Workflow to run. Remaining arguments are passed to that workflow.")
+    parser.add_argument("arguments", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
     return parser
 
 
 def main(argv: list[str] | None = None) -> None:
-    """Dispatch to a workflow CLI while preserving its existing arguments."""
-    parser = _build_parser()
-    args = parser.parse_args(argv)
-
+    parser = _build_parser(); args = parser.parse_args(argv)
     if args.command is None:
-        parser.print_help()
-        return
-
-    handler = _COMMANDS[args.command]
-    handler(args.arguments)
+        parser.print_help(); return
+    _COMMANDS[args.command](args.arguments)
 
 
 if __name__ == "__main__":

--- a/python/src/data_platform_lab/cli/main.py
+++ b/python/src/data_platform_lab/cli/main.py
@@ -23,16 +23,34 @@ _COMMANDS: dict[str, CommandHandler] = {
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(prog="data-platform-lab", description="Unified entry point for Data Platform Lab workflows.")
-    parser.add_argument("command", nargs="?", choices=sorted(_COMMANDS), help="Workflow to run. Remaining arguments are passed to that workflow.")
-    parser.add_argument("arguments", nargs=argparse.REMAINDER, help=argparse.SUPPRESS)
+    """Build the top-level parser without duplicating child command options."""
+    parser = argparse.ArgumentParser(
+        prog="data-platform-lab",
+        description="Unified entry point for Data Platform Lab workflows.",
+    )
+    parser.add_argument(
+        "command",
+        nargs="?",
+        choices=sorted(_COMMANDS),
+        help="Workflow to run. Remaining arguments are passed to that workflow.",
+    )
+    parser.add_argument(
+        "arguments",
+        nargs=argparse.REMAINDER,
+        help=argparse.SUPPRESS,
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = _build_parser(); args = parser.parse_args(argv)
+    """Dispatch to a workflow CLI while preserving its existing arguments."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
     if args.command is None:
-        parser.print_help(); return
+        parser.print_help()
+        return
+
     _COMMANDS[args.command](args.arguments)
 
 

--- a/python/src/data_platform_lab/metadata/__init__.py
+++ b/python/src/data_platform_lab/metadata/__init__.py
@@ -1,0 +1,6 @@
+"""Durable run-metadata contracts and PostgreSQL adapter."""
+
+from data_platform_lab.metadata.postgres import PostgresRunStore
+from data_platform_lab.metadata.store import RunStore
+
+__all__ = ["PostgresRunStore", "RunStore"]

--- a/python/src/data_platform_lab/metadata/cli.py
+++ b/python/src/data_platform_lab/metadata/cli.py
@@ -10,16 +10,36 @@ from data_platform_lab.observability import RunMetadata
 
 
 def main(argv: list[str] | None = None) -> None:
-    parser = argparse.ArgumentParser(description="Verify PostgreSQL run metadata persistence.")
-    parser.add_argument("--dsn", default=os.getenv("DPL_POSTGRES_DSN", "postgresql://data_platform_lab:data_platform_lab@localhost:5432/data_platform_lab"))
+    """Verify PostgreSQL run-metadata persistence through the platform adapter."""
+    parser = argparse.ArgumentParser(
+        description="Verify PostgreSQL run metadata persistence.",
+    )
+    parser.add_argument(
+        "--dsn",
+        default=os.getenv(
+            "DPL_POSTGRES_DSN",
+            "postgresql://data_platform_lab:data_platform_lab@localhost:5432/data_platform_lab",
+        ),
+    )
     args = parser.parse_args(argv)
+
     store = PostgresRunStore.connect(args.dsn)
     try:
-        run = RunMetadata(pipeline_name="platform_metadata_smoke", run_id="smoke", status="success", started_at="2026-09-01T00:00:00+00:00", ended_at="2026-09-01T00:00:01+00:00", duration_seconds=1.0, rows_read=1, rows_written=1)
+        run = RunMetadata(
+            pipeline_name="platform_metadata_smoke",
+            run_id="smoke",
+            status="success",
+            started_at="2026-09-01T00:00:00+00:00",
+            ended_at="2026-09-01T00:00:01+00:00",
+            duration_seconds=1.0,
+            rows_read=1,
+            rows_written=1,
+        )
         store.save(run)
         loaded = store.get(run.pipeline_name, run.run_id)
         if loaded is None or loaded.status != "success" or loaded.rows_written != 1:
             raise RuntimeError("metadata smoke check failed")
+
         print("=== Metadata Store Smoke Check ===")
         print(f"Pipeline : {loaded.pipeline_name}")
         print(f"Run ID   : {loaded.run_id}")

--- a/python/src/data_platform_lab/metadata/cli.py
+++ b/python/src/data_platform_lab/metadata/cli.py
@@ -1,0 +1,32 @@
+"""PostgreSQL metadata-store smoke command."""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from data_platform_lab.metadata import PostgresRunStore
+from data_platform_lab.observability import RunMetadata
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Verify PostgreSQL run metadata persistence.")
+    parser.add_argument("--dsn", default=os.getenv("DPL_POSTGRES_DSN", "postgresql://data_platform_lab:data_platform_lab@localhost:5432/data_platform_lab"))
+    args = parser.parse_args(argv)
+    store = PostgresRunStore.connect(args.dsn)
+    try:
+        run = RunMetadata(pipeline_name="platform_metadata_smoke", run_id="smoke", status="success", started_at="2026-09-01T00:00:00+00:00", ended_at="2026-09-01T00:00:01+00:00", duration_seconds=1.0, rows_read=1, rows_written=1)
+        store.save(run)
+        loaded = store.get(run.pipeline_name, run.run_id)
+        if loaded is None or loaded.status != "success" or loaded.rows_written != 1:
+            raise RuntimeError("metadata smoke check failed")
+        print("=== Metadata Store Smoke Check ===")
+        print(f"Pipeline : {loaded.pipeline_name}")
+        print(f"Run ID   : {loaded.run_id}")
+        print("Round trip: ok")
+    finally:
+        store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/data_platform_lab/metadata/postgres.py
+++ b/python/src/data_platform_lab/metadata/postgres.py
@@ -10,20 +10,43 @@ from data_platform_lab.observability import RunMetadata
 
 
 class Cursor(Protocol):
-    def fetchone(self) -> tuple[Any, ...] | None: ...
-    def fetchall(self) -> list[tuple[Any, ...]]: ...
+    """Minimal cursor operations required by the metadata store."""
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        """Return one result row, if present."""
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        """Return all result rows."""
 
 
 class Connection(Protocol):
-    def execute(self, query: str, params: tuple[object, ...] = ()) -> Cursor: ...
-    def commit(self) -> None: ...
-    def close(self) -> None: ...
+    """Minimal database connection contract used by the adapter."""
+
+    def execute(self, query: str, params: tuple[object, ...] = ()) -> Cursor:
+        """Execute SQL and return a cursor-like result."""
+
+    def commit(self) -> None:
+        """Commit the current transaction."""
+
+    def close(self) -> None:
+        """Close the connection."""
 
 
 _COLUMNS = (
-    "pipeline_name", "run_id", "status", "started_at", "ended_at", "duration_seconds",
-    "rows_read", "rows_written", "rows_rejected", "files_processed", "files_rejected",
-    "warnings", "errors", "extra",
+    "pipeline_name",
+    "run_id",
+    "status",
+    "started_at",
+    "ended_at",
+    "duration_seconds",
+    "rows_read",
+    "rows_written",
+    "rows_rejected",
+    "files_processed",
+    "files_rejected",
+    "warnings",
+    "errors",
+    "extra",
 )
 
 
@@ -31,9 +54,11 @@ class PostgresRunStore:
     """Persist :class:`RunMetadata` snapshots in PostgreSQL."""
 
     def __init__(self, connection: Connection) -> None:
+        """Create a metadata store using an injected database connection."""
         self._connection = connection
 
     def save(self, metadata: RunMetadata) -> None:
+        """Insert or replace one run snapshot by pipeline name and run ID."""
         query = """
         INSERT INTO pipeline_runs (
             pipeline_name, run_id, status, started_at, ended_at, duration_seconds,
@@ -41,49 +66,76 @@ class PostgresRunStore:
             warnings, errors, extra
         ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb,%s::jsonb,%s::jsonb)
         ON CONFLICT (pipeline_name, run_id) DO UPDATE SET
-            status=EXCLUDED.status, started_at=EXCLUDED.started_at, ended_at=EXCLUDED.ended_at,
-            duration_seconds=EXCLUDED.duration_seconds, rows_read=EXCLUDED.rows_read,
-            rows_written=EXCLUDED.rows_written, rows_rejected=EXCLUDED.rows_rejected,
-            files_processed=EXCLUDED.files_processed, files_rejected=EXCLUDED.files_rejected,
-            warnings=EXCLUDED.warnings, errors=EXCLUDED.errors, extra=EXCLUDED.extra,
+            status=EXCLUDED.status,
+            started_at=EXCLUDED.started_at,
+            ended_at=EXCLUDED.ended_at,
+            duration_seconds=EXCLUDED.duration_seconds,
+            rows_read=EXCLUDED.rows_read,
+            rows_written=EXCLUDED.rows_written,
+            rows_rejected=EXCLUDED.rows_rejected,
+            files_processed=EXCLUDED.files_processed,
+            files_rejected=EXCLUDED.files_rejected,
+            warnings=EXCLUDED.warnings,
+            errors=EXCLUDED.errors,
+            extra=EXCLUDED.extra,
             updated_at=now()
         """
-        self._connection.execute(query, (
-            metadata.pipeline_name, metadata.run_id, metadata.status,
-            metadata.started_at or None, metadata.ended_at, metadata.duration_seconds,
-            metadata.rows_read, metadata.rows_written, metadata.rows_rejected,
-            metadata.files_processed, metadata.files_rejected,
-            json.dumps(metadata.warnings), json.dumps(metadata.errors), json.dumps(metadata.extra),
-        ))
+        self._connection.execute(
+            query,
+            (
+                metadata.pipeline_name,
+                metadata.run_id,
+                metadata.status,
+                metadata.started_at or None,
+                metadata.ended_at,
+                metadata.duration_seconds,
+                metadata.rows_read,
+                metadata.rows_written,
+                metadata.rows_rejected,
+                metadata.files_processed,
+                metadata.files_rejected,
+                json.dumps(metadata.warnings),
+                json.dumps(metadata.errors),
+                json.dumps(metadata.extra),
+            ),
+        )
         self._connection.commit()
 
     def get(self, pipeline_name: str, run_id: str) -> RunMetadata | None:
-        row = self._connection.execute(
-            f"SELECT {', '.join(_COLUMNS)} FROM pipeline_runs WHERE pipeline_name=%s AND run_id=%s",
-            (pipeline_name, run_id),
-        ).fetchone()
+        """Return one persisted run snapshot, if it exists."""
+        query = (
+            f"SELECT {', '.join(_COLUMNS)} FROM pipeline_runs "
+            "WHERE pipeline_name=%s AND run_id=%s"
+        )
+        row = self._connection.execute(query, (pipeline_name, run_id)).fetchone()
         return self._to_metadata(row) if row is not None else None
 
     def list_recent(self, limit: int = 20) -> list[RunMetadata]:
+        """Return the most recent persisted run snapshots."""
         if not isinstance(limit, int) or isinstance(limit, bool):
             raise TypeError("limit must be an integer")
         if limit < 1:
             raise ValueError("limit must be positive")
-        rows = self._connection.execute(
-            f"SELECT {', '.join(_COLUMNS)} FROM pipeline_runs ORDER BY started_at DESC NULLS LAST, recorded_at DESC LIMIT %s",
-            (limit,),
-        ).fetchall()
+
+        query = (
+            f"SELECT {', '.join(_COLUMNS)} FROM pipeline_runs "
+            "ORDER BY started_at DESC NULLS LAST, recorded_at DESC LIMIT %s"
+        )
+        rows = self._connection.execute(query, (limit,)).fetchall()
         return [self._to_metadata(row) for row in rows]
 
     def close(self) -> None:
+        """Close the underlying database connection."""
         self._connection.close()
 
     @classmethod
     def connect(cls, dsn: str) -> PostgresRunStore:
+        """Create the adapter from a psycopg DSN."""
         try:
             psycopg = import_module("psycopg")
         except ModuleNotFoundError as exc:
             raise RuntimeError("psycopg is required for PostgreSQL metadata storage") from exc
+
         factory = getattr(psycopg, "connect", None)
         if not callable(factory):
             raise RuntimeError("psycopg installation does not expose connect()")
@@ -91,14 +143,35 @@ class PostgresRunStore:
 
     @staticmethod
     def _to_metadata(row: tuple[Any, ...]) -> RunMetadata:
+        """Convert one database row back into the shared RunMetadata model."""
         warnings = row[11] if isinstance(row[11], list) else json.loads(row[11])
         errors = row[12] if isinstance(row[12], list) else json.loads(row[12])
         extra = row[13] if isinstance(row[13], dict) else json.loads(row[13])
+
+        started_at = (
+            row[3].isoformat()
+            if hasattr(row[3], "isoformat")
+            else str(row[3] or "")
+        )
+        ended_at = (
+            row[4].isoformat()
+            if hasattr(row[4], "isoformat")
+            else (str(row[4]) if row[4] else None)
+        )
+
         return RunMetadata(
-            pipeline_name=str(row[0]), run_id=str(row[1]), status=str(row[2]),
-            started_at=row[3].isoformat() if hasattr(row[3], "isoformat") else str(row[3] or ""),
-            ended_at=row[4].isoformat() if hasattr(row[4], "isoformat") else (str(row[4]) if row[4] else None),
-            duration_seconds=float(row[5]), rows_read=int(row[6]), rows_written=int(row[7]),
-            rows_rejected=int(row[8]), files_processed=int(row[9]), files_rejected=int(row[10]),
-            warnings=list(warnings), errors=list(errors), extra=dict(extra),
+            pipeline_name=str(row[0]),
+            run_id=str(row[1]),
+            status=str(row[2]),
+            started_at=started_at,
+            ended_at=ended_at,
+            duration_seconds=float(row[5]),
+            rows_read=int(row[6]),
+            rows_written=int(row[7]),
+            rows_rejected=int(row[8]),
+            files_processed=int(row[9]),
+            files_rejected=int(row[10]),
+            warnings=list(warnings),
+            errors=list(errors),
+            extra=dict(extra),
         )

--- a/python/src/data_platform_lab/metadata/postgres.py
+++ b/python/src/data_platform_lab/metadata/postgres.py
@@ -104,8 +104,7 @@ class PostgresRunStore:
     def get(self, pipeline_name: str, run_id: str) -> RunMetadata | None:
         """Return one persisted run snapshot, if it exists."""
         query = (
-            f"SELECT {', '.join(_COLUMNS)} FROM pipeline_runs "
-            "WHERE pipeline_name=%s AND run_id=%s"
+            f"SELECT {', '.join(_COLUMNS)} FROM pipeline_runs WHERE pipeline_name=%s AND run_id=%s"
         )
         row = self._connection.execute(query, (pipeline_name, run_id)).fetchone()
         return self._to_metadata(row) if row is not None else None
@@ -148,11 +147,7 @@ class PostgresRunStore:
         errors = row[12] if isinstance(row[12], list) else json.loads(row[12])
         extra = row[13] if isinstance(row[13], dict) else json.loads(row[13])
 
-        started_at = (
-            row[3].isoformat()
-            if hasattr(row[3], "isoformat")
-            else str(row[3] or "")
-        )
+        started_at = row[3].isoformat() if hasattr(row[3], "isoformat") else str(row[3] or "")
         ended_at = (
             row[4].isoformat()
             if hasattr(row[4], "isoformat")

--- a/python/src/data_platform_lab/metadata/postgres.py
+++ b/python/src/data_platform_lab/metadata/postgres.py
@@ -1,0 +1,104 @@
+"""PostgreSQL implementation of the run-metadata persistence boundary."""
+
+from __future__ import annotations
+
+import json
+from importlib import import_module
+from typing import Any, Protocol, cast
+
+from data_platform_lab.observability import RunMetadata
+
+
+class Cursor(Protocol):
+    def fetchone(self) -> tuple[Any, ...] | None: ...
+    def fetchall(self) -> list[tuple[Any, ...]]: ...
+
+
+class Connection(Protocol):
+    def execute(self, query: str, params: tuple[object, ...] = ()) -> Cursor: ...
+    def commit(self) -> None: ...
+    def close(self) -> None: ...
+
+
+_COLUMNS = (
+    "pipeline_name", "run_id", "status", "started_at", "ended_at", "duration_seconds",
+    "rows_read", "rows_written", "rows_rejected", "files_processed", "files_rejected",
+    "warnings", "errors", "extra",
+)
+
+
+class PostgresRunStore:
+    """Persist :class:`RunMetadata` snapshots in PostgreSQL."""
+
+    def __init__(self, connection: Connection) -> None:
+        self._connection = connection
+
+    def save(self, metadata: RunMetadata) -> None:
+        query = """
+        INSERT INTO pipeline_runs (
+            pipeline_name, run_id, status, started_at, ended_at, duration_seconds,
+            rows_read, rows_written, rows_rejected, files_processed, files_rejected,
+            warnings, errors, extra
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb,%s::jsonb,%s::jsonb)
+        ON CONFLICT (pipeline_name, run_id) DO UPDATE SET
+            status=EXCLUDED.status, started_at=EXCLUDED.started_at, ended_at=EXCLUDED.ended_at,
+            duration_seconds=EXCLUDED.duration_seconds, rows_read=EXCLUDED.rows_read,
+            rows_written=EXCLUDED.rows_written, rows_rejected=EXCLUDED.rows_rejected,
+            files_processed=EXCLUDED.files_processed, files_rejected=EXCLUDED.files_rejected,
+            warnings=EXCLUDED.warnings, errors=EXCLUDED.errors, extra=EXCLUDED.extra,
+            updated_at=now()
+        """
+        self._connection.execute(query, (
+            metadata.pipeline_name, metadata.run_id, metadata.status,
+            metadata.started_at or None, metadata.ended_at, metadata.duration_seconds,
+            metadata.rows_read, metadata.rows_written, metadata.rows_rejected,
+            metadata.files_processed, metadata.files_rejected,
+            json.dumps(metadata.warnings), json.dumps(metadata.errors), json.dumps(metadata.extra),
+        ))
+        self._connection.commit()
+
+    def get(self, pipeline_name: str, run_id: str) -> RunMetadata | None:
+        row = self._connection.execute(
+            f"SELECT {', '.join(_COLUMNS)} FROM pipeline_runs WHERE pipeline_name=%s AND run_id=%s",
+            (pipeline_name, run_id),
+        ).fetchone()
+        return self._to_metadata(row) if row is not None else None
+
+    def list_recent(self, limit: int = 20) -> list[RunMetadata]:
+        if not isinstance(limit, int) or isinstance(limit, bool):
+            raise TypeError("limit must be an integer")
+        if limit < 1:
+            raise ValueError("limit must be positive")
+        rows = self._connection.execute(
+            f"SELECT {', '.join(_COLUMNS)} FROM pipeline_runs ORDER BY started_at DESC NULLS LAST, recorded_at DESC LIMIT %s",
+            (limit,),
+        ).fetchall()
+        return [self._to_metadata(row) for row in rows]
+
+    def close(self) -> None:
+        self._connection.close()
+
+    @classmethod
+    def connect(cls, dsn: str) -> PostgresRunStore:
+        try:
+            psycopg = import_module("psycopg")
+        except ModuleNotFoundError as exc:
+            raise RuntimeError("psycopg is required for PostgreSQL metadata storage") from exc
+        factory = getattr(psycopg, "connect", None)
+        if not callable(factory):
+            raise RuntimeError("psycopg installation does not expose connect()")
+        return cls(cast(Connection, factory(dsn)))
+
+    @staticmethod
+    def _to_metadata(row: tuple[Any, ...]) -> RunMetadata:
+        warnings = row[11] if isinstance(row[11], list) else json.loads(row[11])
+        errors = row[12] if isinstance(row[12], list) else json.loads(row[12])
+        extra = row[13] if isinstance(row[13], dict) else json.loads(row[13])
+        return RunMetadata(
+            pipeline_name=str(row[0]), run_id=str(row[1]), status=str(row[2]),
+            started_at=row[3].isoformat() if hasattr(row[3], "isoformat") else str(row[3] or ""),
+            ended_at=row[4].isoformat() if hasattr(row[4], "isoformat") else (str(row[4]) if row[4] else None),
+            duration_seconds=float(row[5]), rows_read=int(row[6]), rows_written=int(row[7]),
+            rows_rejected=int(row[8]), files_processed=int(row[9]), files_rejected=int(row[10]),
+            warnings=list(warnings), errors=list(errors), extra=dict(extra),
+        )

--- a/python/src/data_platform_lab/metadata/store.py
+++ b/python/src/data_platform_lab/metadata/store.py
@@ -1,0 +1,21 @@
+"""Run metadata persistence boundary."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from data_platform_lab.observability import RunMetadata
+
+
+@runtime_checkable
+class RunStore(Protocol):
+    """Minimal durable history contract for pipeline runs."""
+
+    def save(self, metadata: RunMetadata) -> None:
+        """Insert or replace one run snapshot."""
+
+    def get(self, pipeline_name: str, run_id: str) -> RunMetadata | None:
+        """Return one run snapshot if present."""
+
+    def list_recent(self, limit: int = 20) -> list[RunMetadata]:
+        """Return recent runs ordered newest first."""

--- a/python/tests/test_metadata_postgres.py
+++ b/python/tests/test_metadata_postgres.py
@@ -9,31 +9,61 @@ from data_platform_lab.observability import RunMetadata
 
 
 class FakeCursor:
-    def __init__(self, rows: list[tuple[Any, ...]]) -> None: self.rows = rows
-    def fetchone(self) -> tuple[Any, ...] | None: return self.rows[0] if self.rows else None
-    def fetchall(self) -> list[tuple[Any, ...]]: return self.rows
+    """Minimal cursor used by metadata-store unit tests."""
+
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self.rows = rows
+
+    def fetchone(self) -> tuple[Any, ...] | None:
+        return self.rows[0] if self.rows else None
+
+    def fetchall(self) -> list[tuple[Any, ...]]:
+        return self.rows
 
 
 class FakeConnection:
+    """In-memory connection that records SQL calls."""
+
     def __init__(self) -> None:
         self.calls: list[tuple[str, tuple[object, ...]]] = []
         self.rows: list[tuple[Any, ...]] = []
         self.commits = 0
         self.closed = False
+
     def execute(self, query: str, params: tuple[object, ...] = ()) -> FakeCursor:
-        self.calls.append((query, params)); return FakeCursor(self.rows)
-    def commit(self) -> None: self.commits += 1
-    def close(self) -> None: self.closed = True
+        self.calls.append((query, params))
+        return FakeCursor(self.rows)
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def _metadata() -> RunMetadata:
-    return RunMetadata(pipeline_name="demo", run_id="r1", status="success", started_at="2026-09-01T00:00:00+00:00", ended_at="2026-09-01T00:00:01+00:00", duration_seconds=1.0, rows_read=10, rows_written=9, rows_rejected=1, files_processed=1, extra={"source": "test"})
+    return RunMetadata(
+        pipeline_name="demo",
+        run_id="r1",
+        status="success",
+        started_at="2026-09-01T00:00:00+00:00",
+        ended_at="2026-09-01T00:00:01+00:00",
+        duration_seconds=1.0,
+        rows_read=10,
+        rows_written=9,
+        rows_rejected=1,
+        files_processed=1,
+        extra={"source": "test"},
+    )
 
 
 def test_postgres_store_satisfies_contract_and_upserts() -> None:
-    connection = FakeConnection(); store = PostgresRunStore(connection)
+    connection = FakeConnection()
+    store = PostgresRunStore(connection)
+
     assert isinstance(store, RunStore)
     store.save(_metadata())
+
     assert connection.commits == 1
     assert "ON CONFLICT" in connection.calls[0][0]
     assert connection.calls[0][1][0:3] == ("demo", "r1", "success")
@@ -41,8 +71,28 @@ def test_postgres_store_satisfies_contract_and_upserts() -> None:
 
 def test_postgres_store_get_and_list_recent() -> None:
     connection = FakeConnection()
-    connection.rows = [("demo","r1","success","2026-09-01T00:00:00+00:00","2026-09-01T00:00:01+00:00",1.0,10,9,1,1,0,[],[],{"source":"test"})]
+    connection.rows = [
+        (
+            "demo",
+            "r1",
+            "success",
+            "2026-09-01T00:00:00+00:00",
+            "2026-09-01T00:00:01+00:00",
+            1.0,
+            10,
+            9,
+            1,
+            1,
+            0,
+            [],
+            [],
+            {"source": "test"},
+        )
+    ]
     store = PostgresRunStore(connection)
+
     loaded = store.get("demo", "r1")
-    assert loaded is not None and loaded.rows_written == 9
+
+    assert loaded is not None
+    assert loaded.rows_written == 9
     assert store.list_recent(5)[0].extra == {"source": "test"}

--- a/python/tests/test_metadata_postgres.py
+++ b/python/tests/test_metadata_postgres.py
@@ -1,0 +1,48 @@
+"""Tests for PostgreSQL run metadata persistence."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from data_platform_lab.metadata import PostgresRunStore, RunStore
+from data_platform_lab.observability import RunMetadata
+
+
+class FakeCursor:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None: self.rows = rows
+    def fetchone(self) -> tuple[Any, ...] | None: return self.rows[0] if self.rows else None
+    def fetchall(self) -> list[tuple[Any, ...]]: return self.rows
+
+
+class FakeConnection:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+        self.rows: list[tuple[Any, ...]] = []
+        self.commits = 0
+        self.closed = False
+    def execute(self, query: str, params: tuple[object, ...] = ()) -> FakeCursor:
+        self.calls.append((query, params)); return FakeCursor(self.rows)
+    def commit(self) -> None: self.commits += 1
+    def close(self) -> None: self.closed = True
+
+
+def _metadata() -> RunMetadata:
+    return RunMetadata(pipeline_name="demo", run_id="r1", status="success", started_at="2026-09-01T00:00:00+00:00", ended_at="2026-09-01T00:00:01+00:00", duration_seconds=1.0, rows_read=10, rows_written=9, rows_rejected=1, files_processed=1, extra={"source": "test"})
+
+
+def test_postgres_store_satisfies_contract_and_upserts() -> None:
+    connection = FakeConnection(); store = PostgresRunStore(connection)
+    assert isinstance(store, RunStore)
+    store.save(_metadata())
+    assert connection.commits == 1
+    assert "ON CONFLICT" in connection.calls[0][0]
+    assert connection.calls[0][1][0:3] == ("demo", "r1", "success")
+
+
+def test_postgres_store_get_and_list_recent() -> None:
+    connection = FakeConnection()
+    connection.rows = [("demo","r1","success","2026-09-01T00:00:00+00:00","2026-09-01T00:00:01+00:00",1.0,10,9,1,1,0,[],[],{"source":"test"})]
+    store = PostgresRunStore(connection)
+    loaded = store.get("demo", "r1")
+    assert loaded is not None and loaded.rows_written == 9
+    assert store.list_recent(5)[0].extra == {"source": "test"}

--- a/sql/platform/001_pipeline_runs.sql
+++ b/sql/platform/001_pipeline_runs.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS pipeline_runs (
+    pipeline_name TEXT NOT NULL,
+    run_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('pending','running','success','failed')),
+    started_at TIMESTAMPTZ,
+    ended_at TIMESTAMPTZ,
+    duration_seconds DOUBLE PRECISION NOT NULL DEFAULT 0 CHECK (duration_seconds >= 0),
+    rows_read BIGINT NOT NULL DEFAULT 0 CHECK (rows_read >= 0),
+    rows_written BIGINT NOT NULL DEFAULT 0 CHECK (rows_written >= 0),
+    rows_rejected BIGINT NOT NULL DEFAULT 0 CHECK (rows_rejected >= 0),
+    files_processed BIGINT NOT NULL DEFAULT 0 CHECK (files_processed >= 0),
+    files_rejected BIGINT NOT NULL DEFAULT 0 CHECK (files_rejected >= 0),
+    warnings JSONB NOT NULL DEFAULT '[]'::jsonb,
+    errors JSONB NOT NULL DEFAULT '[]'::jsonb,
+    extra JSONB NOT NULL DEFAULT '{}'::jsonb,
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (pipeline_name, run_id)
+);
+
+CREATE INDEX IF NOT EXISTS pipeline_runs_started_at_idx
+    ON pipeline_runs (started_at DESC NULLS LAST);


### PR DESCRIPTION
## Summary

Implements Milestone 3 Phase 3 by making the existing `RunMetadata` model durable in PostgreSQL.

- adds a minimal `RunStore` contract in Python
- adds a psycopg-backed `PostgresRunStore` with idempotent upsert semantics
- adds the equivalent JavaScript `PostgresRunStore` against an injected `query()` client
- adds the `pipeline_runs` PostgreSQL schema keyed by `(pipeline_name, run_id)`
- adds PostgreSQL 18.6 to the local Compose stack
- adds `data-platform-lab metadata` as the Python wire-level smoke command
- adds a dedicated PostgreSQL integration workflow
- adds ER and platform topology diagrams for the metadata layer
- keeps JavaScript driver selection deferred until it can be introduced with a committed lockfile

## Design

Phase 3 reuses the existing observability metadata rather than introducing a competing run model:

```text
RunTracker -> RunMetadata -> RunStore -> PostgresRunStore -> PostgreSQL
```

The first schema is intentionally narrow. It stores lifecycle timestamps, status, counters, warnings/errors and extensible JSON metadata. The compound primary key lets a running snapshot be replaced by the finished snapshot for the same run.

## Validation

Unit tests use injected fake database clients/connections. The PostgreSQL integration workflow starts the real Compose service, runs the schema initialization, writes/reads the metadata smoke record through psycopg, and inspects the persisted row with psql.

## Next

After this phase is stable, Milestone 3 can move to Iceberg analytical tables over the existing S3-compatible object storage boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes pipeline run history durable by persisting the existing `RunMetadata` model in PostgreSQL through a new `RunStore` contract. Run snapshots are now upserted into a `pipeline_runs` table keyed by `(pipeline_name, run_id)` instead of only living in the in-memory observability layer.

- Adds psycopg-backed Python and injected-client JavaScript `PostgresRunStore` implementations with idempotent upsert semantics.
- Adds PostgreSQL 18.6 with the `pipeline_runs` schema to the local Compose stack and a new `data-platform-lab metadata` smoke command.
- Reuses the existing observability `RunMetadata` shape, so no competing run model is introduced.
- Defers a committed JavaScript PostgreSQL driver dependency to keep Yarn reproducible.
- Updates Milestone 3 docs with ER and platform topology diagrams for the metadata layer.

**Validation**

- Unit tests fake database clients and connections and check both implementations satisfy the `RunStore` contract.
- A dedicated CI integration workflow starts the real Compose service, writes and reads a smoke record through psycopg, and inspects the persisted row via psql.

<sup>Written for commit b265044984d075ea663a2ce6ec23438c3839635e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/data-platform-lab/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

