### PR TITLE
Add Iceberg analytical tables over S3

### DIFF
--- a/.github/workflows/iceberg-integration.yml
+++ b/.github/workflows/iceberg-integration.yml
@@ -1,0 +1,67 @@
+name: Iceberg Integration
+
+on:
+  push:
+    paths:
+      - "compose.yaml"
+      - "infra/garage/**"
+      - "python/pyproject.toml"
+      - "python/src/data_platform_lab/iceberg/**"
+      - "python/src/data_platform_lab/cli/main.py"
+      - ".github/workflows/iceberg-integration.yml"
+  pull_request:
+    paths:
+      - "compose.yaml"
+      - "infra/garage/**"
+      - "python/pyproject.toml"
+      - "python/src/data_platform_lab/iceberg/**"
+      - "python/src/data_platform_lab/cli/main.py"
+      - ".github/workflows/iceberg-integration.yml"
+
+jobs:
+  iceberg:
+    name: PostgreSQL catalog + Garage warehouse
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start PostgreSQL
+        run: docker compose up -d --wait postgres
+
+      - name: Start Garage
+        run: sh infra/garage/bootstrap.sh
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install Python dependencies
+        working-directory: python
+        run: poetry install --no-interaction
+
+      - name: Iceberg round trip
+        working-directory: python
+        shell: bash
+        run: |
+          set -a
+          source ../infra/garage/dev.env
+          set +a
+          poetry run data-platform-lab iceberg
+
+      - name: Inspect Iceberg catalog tables
+        run: |
+          docker compose exec -T postgres psql -U data_platform_lab -d data_platform_lab \
+            -c "SELECT tablename FROM pg_tables WHERE tablename LIKE 'iceberg%';"
+
+      - name: Diagnostics
+        if: failure()
+        run: |
+          docker compose logs postgres
+          docker compose logs garage
+
+      - name: Stop services
+        if: always()
+        run: docker compose down -v

--- a/docs/iceberg-analytical-tables.md
+++ b/docs/iceberg-analytical-tables.md
@@ -1,0 +1,55 @@
+# Iceberg analytical tables
+
+Milestone 3 Phase 4 adds an analytical table layer without changing the two platform boundaries already established for object storage and operational run metadata.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    W[Python analytical workflow] --> I[IcebergTableStore]
+    I --> P[PyIceberg]
+    P --> C[SQL catalog]
+    C --> PG[(PostgreSQL 18.6)]
+    P --> F[Iceberg FileIO]
+    F --> S3[S3-compatible API]
+    S3 --> G[(Garage)]
+```
+
+PostgreSQL contains Iceberg catalog state. Table data, manifests, and Iceberg metadata files live under the S3 warehouse. The analytical data path therefore does not store bulk data in PostgreSQL.
+
+## Local smoke
+
+Start PostgreSQL and Garage, then load the development S3 credentials:
+
+```bash
+docker compose up -d --wait postgres
+sh infra/garage/bootstrap.sh
+. infra/garage/dev.env
+```
+
+Run the table smoke:
+
+```bash
+cd python
+poetry install
+poetry run data-platform-lab iceberg
+```
+
+The smoke creates `analytics.events_smoke`, appends one Arrow record, scans the table through PyIceberg, and requires the row to be visible.
+
+## Catalog and warehouse
+
+The local defaults are:
+
+```text
+catalog:   platform
+catalog DB: PostgreSQL
+warehouse: s3://data-platform-lab/iceberg
+S3 API:    http://localhost:3900
+```
+
+The SQL catalog and S3 warehouse are independently replaceable infrastructure choices. Production deployments can point the same application boundary at another PostgreSQL-compatible catalog database and an S3 endpoint with real credentials.
+
+## Scope
+
+This phase deliberately starts in Python because PyIceberg is the mature native library used for the live Iceberg contract. JavaScript remains part of the surrounding platform, but Phase 4 does not invent a second Iceberg implementation with weaker ecosystem support.

--- a/docs/milestone-m3.md
+++ b/docs/milestone-m3.md
@@ -16,22 +16,26 @@ flowchart LR
     JS[JavaScript workflows] --> B
     PY --> R[RunStore]
     JS --> R
+    PY --> I[IcebergTableStore]
     B --> Local[LocalBlobStore]
     B --> S3[S3BlobStore]
     S3 --> Garage[(Garage S3)]
     R --> PG[PostgresRunStore]
     PG --> DB[(PostgreSQL 18.6)]
+    I --> PI[PyIceberg]
+    PI --> DB
+    PI --> Garage
 ```
 
 ## Sequence
 
 1. storage and unified-command boundaries — complete;
 2. S3-compatible storage and Garage integration — complete;
-3. PostgreSQL-backed run/metadata store — in progress;
-4. Iceberg analytical tables over object storage;
+3. PostgreSQL-backed run/metadata store — complete;
+4. Iceberg analytical tables over object storage — in progress;
 5. event-broker adapter for streaming;
 6. end-to-end platform failure/recovery demo.
 
-Phase 3 reuses the existing observability `RunMetadata` shape. The initial database contains one deliberately narrow `pipeline_runs` table, keyed by `(pipeline_name, run_id)` and updated idempotently as a run moves from running to success/failed.
+Phase 3 reuses the existing observability `RunMetadata` shape. Phase 4 adds a PyIceberg SQL catalog in PostgreSQL while keeping Iceberg table data and metadata files in the S3-compatible Garage warehouse.
 
-See [PostgreSQL run metadata](postgres-run-metadata.md) for the ER diagram, persistence contract, and local validation flow.
+See [PostgreSQL run metadata](postgres-run-metadata.md) for the operational metadata layer and [Iceberg analytical tables](iceberg-analytical-tables.md) for the analytical-table architecture and local validation flow.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -11,6 +11,7 @@ packages = [{ include = "data_platform_lab", from = "src" }]
 python = ">=3.11"
 boto3 = ">=1.40,<2.0"
 psycopg = {version = ">=3.2,<4.0", extras = ["binary"]}
+pyiceberg = {version = "0.11.1", extras = ["pyarrow", "s3fs", "sql-postgres"]}
 
 [tool.poetry.group.dev.dependencies]
 pytest = ">=8.0"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT"
 packages = [{ include = "data_platform_lab", from = "src" }]
 
 [tool.poetry.dependencies]
-python = ">=3.11"
+python = ">=3.11,<4.0"
 boto3 = ">=1.40,<2.0"
 psycopg = {version = ">=3.2,<4.0", extras = ["binary"]}
 pyiceberg = {version = "0.11.1", extras = ["pyarrow", "s3fs", "sql-postgres"]}

--- a/python/src/data_platform_lab/cli/main.py
+++ b/python/src/data_platform_lab/cli/main.py
@@ -6,6 +6,7 @@ import argparse
 from collections.abc import Callable
 
 from data_platform_lab.benchmark.cli import main as benchmark_main
+from data_platform_lab.iceberg.cli import main as iceberg_main
 from data_platform_lab.metadata.cli import main as metadata_main
 from data_platform_lab.storage.cli import main as storage_main
 from data_platform_lab.streaming.cli import main as streaming_main
@@ -15,6 +16,7 @@ CommandHandler = Callable[[list[str] | None], None]
 
 _COMMANDS: dict[str, CommandHandler] = {
     "benchmark": benchmark_main,
+    "iceberg": iceberg_main,
     "metadata": metadata_main,
     "storage": storage_main,
     "stream": streaming_main,

--- a/python/src/data_platform_lab/iceberg/__init__.py
+++ b/python/src/data_platform_lab/iceberg/__init__.py
@@ -1,0 +1,6 @@
+"""Iceberg analytical-table boundary for Milestone 3."""
+
+from data_platform_lab.iceberg.catalog import IcebergCatalogConfig, build_catalog
+from data_platform_lab.iceberg.store import IcebergTableStore
+
+__all__ = ["IcebergCatalogConfig", "IcebergTableStore", "build_catalog"]

--- a/python/src/data_platform_lab/iceberg/catalog.py
+++ b/python/src/data_platform_lab/iceberg/catalog.py
@@ -1,0 +1,55 @@
+"""PyIceberg SQL-catalog construction for the local platform."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Any
+
+
+@dataclass(frozen=True)
+class IcebergCatalogConfig:
+    """Connection settings for the local Iceberg catalog and S3 warehouse."""
+
+    catalog_name: str
+    postgres_dsn: str
+    warehouse: str
+    s3_endpoint: str
+    s3_access_key_id: str
+    s3_secret_access_key: str
+    s3_region: str = "garage"
+
+
+def _sqlalchemy_dsn(dsn: str) -> str:
+    """Select SQLAlchemy's psycopg 3 dialect for ordinary PostgreSQL DSNs."""
+    if dsn.startswith("postgresql+psycopg://"):
+        return dsn
+    if dsn.startswith("postgresql://"):
+        return dsn.replace("postgresql://", "postgresql+psycopg://", 1)
+    return dsn
+
+
+def build_catalog(config: IcebergCatalogConfig) -> Any:
+    """Build a PyIceberg SQL catalog backed by PostgreSQL and S3-compatible storage."""
+    try:
+        catalog_module = import_module("pyiceberg.catalog")
+    except ModuleNotFoundError as exc:
+        raise RuntimeError("PyIceberg is required for analytical table storage") from exc
+
+    load_catalog = getattr(catalog_module, "load_catalog", None)
+    if not callable(load_catalog):
+        raise RuntimeError("PyIceberg installation does not expose load_catalog()")
+
+    return load_catalog(
+        config.catalog_name,
+        type="sql",
+        uri=_sqlalchemy_dsn(config.postgres_dsn),
+        warehouse=config.warehouse,
+        **{
+            "s3.endpoint": config.s3_endpoint,
+            "s3.access-key-id": config.s3_access_key_id,
+            "s3.secret-access-key": config.s3_secret_access_key,
+            "s3.region": config.s3_region,
+            "s3.force-virtual-addressing": "false",
+        },
+    )

--- a/python/src/data_platform_lab/iceberg/cli.py
+++ b/python/src/data_platform_lab/iceberg/cli.py
@@ -1,0 +1,88 @@
+"""Wire-level smoke command for Iceberg analytical tables."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from importlib import import_module
+
+from data_platform_lab.iceberg import IcebergCatalogConfig, IcebergTableStore, build_catalog
+
+_DEFAULT_DSN = "postgresql://data_platform_lab:data_platform_lab@localhost:5432/data_platform_lab"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Verify Iceberg catalog and S3 table storage.")
+    parser.add_argument("--catalog", default="platform")
+    parser.add_argument("--namespace", default="analytics")
+    parser.add_argument("--table", default="events_smoke")
+    parser.add_argument("--postgres-dsn", default=os.getenv("DPL_POSTGRES_DSN", _DEFAULT_DSN))
+    parser.add_argument(
+        "--warehouse",
+        default=os.getenv("DPL_ICEBERG_WAREHOUSE", "s3://data-platform-lab/iceberg"),
+    )
+    parser.add_argument(
+        "--s3-endpoint",
+        default=os.getenv("DPL_S3_ENDPOINT_URL", "http://localhost:3900"),
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Create, append, and scan one Iceberg table through the local platform services."""
+    args = _build_parser().parse_args(argv)
+    access_key = os.getenv("AWS_ACCESS_KEY_ID")
+    secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+    if not access_key or not secret_key:
+        raise RuntimeError("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required")
+
+    try:
+        pa = import_module("pyarrow")
+    except ModuleNotFoundError as exc:
+        raise RuntimeError("PyArrow is required for the Iceberg smoke check") from exc
+
+    catalog = build_catalog(
+        IcebergCatalogConfig(
+            catalog_name=args.catalog,
+            postgres_dsn=args.postgres_dsn,
+            warehouse=args.warehouse,
+            s3_endpoint=args.s3_endpoint,
+            s3_access_key_id=access_key,
+            s3_secret_access_key=secret_key,
+            s3_region=os.getenv("AWS_DEFAULT_REGION", "garage"),
+        )
+    )
+    store = IcebergTableStore(catalog)
+    identifier = f"{args.namespace}.{args.table}"
+    schema = pa.schema(
+        [
+            ("event_id", pa.string()),
+            ("event_time", pa.timestamp("us", tz="UTC")),
+            ("value", pa.float64()),
+        ]
+    )
+    store.ensure_table(identifier, schema)
+    batch = pa.Table.from_pylist(
+        [
+            {
+                "event_id": "smoke-1",
+                "event_time": "2026-09-01T00:00:00+00:00",
+                "value": 1.0,
+            }
+        ],
+        schema=schema,
+    )
+    store.append(identifier, batch)
+    count = store.row_count(identifier)
+    if count < 1:
+        raise RuntimeError("Iceberg smoke check failed: appended row was not visible")
+
+    print("=== Iceberg Table Smoke Check ===")
+    print(f"Table     : {identifier}")
+    print(f"Warehouse : {args.warehouse}")
+    print(f"Rows      : {count}")
+    print("Round trip: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/data_platform_lab/iceberg/cli.py
+++ b/python/src/data_platform_lab/iceberg/cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+from datetime import UTC, datetime
 from importlib import import_module
 
 from data_platform_lab.iceberg import IcebergCatalogConfig, IcebergTableStore, build_catalog
@@ -66,7 +67,7 @@ def main(argv: list[str] | None = None) -> None:
         [
             {
                 "event_id": "smoke-1",
-                "event_time": "2026-09-01T00:00:00+00:00",
+                "event_time": datetime(2026, 9, 1, tzinfo=UTC),
                 "value": 1.0,
             }
         ],

--- a/python/src/data_platform_lab/iceberg/store.py
+++ b/python/src/data_platform_lab/iceberg/store.py
@@ -23,6 +23,17 @@ class IcebergTableStore:
     def __init__(self, catalog: Catalog) -> None:
         self._catalog = catalog
 
+    @staticmethod
+    def _namespace(identifier: str) -> str:
+        """Return the namespace from a qualified Iceberg table identifier."""
+        if not isinstance(identifier, str):
+            raise TypeError("Iceberg identifier must be a string")
+
+        namespace, separator, table_name = identifier.partition(".")
+        if not separator or not namespace.strip() or not table_name.strip():
+            raise ValueError("Iceberg identifiers must include a namespace")
+        return namespace
+
     def ensure_namespace(self, namespace: str) -> None:
         """Create *namespace* once if it is not already present."""
         if (namespace,) not in self._catalog.list_namespaces():
@@ -30,19 +41,19 @@ class IcebergTableStore:
 
     def ensure_table(self, identifier: str, schema: Any) -> Any:
         """Return an existing table or create it using *schema*."""
-        namespace, _, _ = identifier.partition(".")
-        if not namespace:
-            raise ValueError("Iceberg identifiers must include a namespace")
+        namespace = self._namespace(identifier)
         self.ensure_namespace(namespace)
         return self._catalog.create_table_if_not_exists(identifier, schema)
 
     def append(self, identifier: str, table_data: Any) -> None:
         """Append one Arrow table to an existing Iceberg table."""
+        self._namespace(identifier)
         table = self._catalog.load_table(identifier)
         table.append(table_data)
 
     def row_count(self, identifier: str) -> int:
         """Scan an Iceberg table and return its current row count."""
+        self._namespace(identifier)
         table = self._catalog.load_table(identifier)
         arrow_table = table.scan().to_arrow()
         return int(arrow_table.num_rows)

--- a/python/src/data_platform_lab/iceberg/store.py
+++ b/python/src/data_platform_lab/iceberg/store.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import Any, Protocol
 
+Namespace = tuple[str, ...]
+
 
 class Catalog(Protocol):
     """Subset of the PyIceberg catalog surface used by the platform."""
 
-    def list_namespaces(self) -> list[tuple[str, ...]]: ...
-
-    def create_namespace(self, namespace: str) -> None: ...
+    def create_namespace_if_not_exists(self, namespace: Namespace) -> None: ...
 
     def create_table_if_not_exists(self, identifier: str, schema: Any) -> Any: ...
 
@@ -24,20 +24,23 @@ class IcebergTableStore:
         self._catalog = catalog
 
     @staticmethod
-    def _namespace(identifier: str) -> str:
-        """Return the namespace from a qualified Iceberg table identifier."""
+    def _namespace(identifier: str) -> Namespace:
+        """Return the full namespace from a qualified Iceberg table identifier."""
         if not isinstance(identifier, str):
             raise TypeError("Iceberg identifier must be a string")
 
-        namespace, separator, table_name = identifier.partition(".")
-        if not separator or not namespace.strip() or not table_name.strip():
-            raise ValueError("Iceberg identifiers must include a namespace")
-        return namespace
+        components = tuple(identifier.split("."))
+        if len(components) < 2 or any(
+            not component or component != component.strip() for component in components
+        ):
+            raise ValueError(
+                "Iceberg identifiers must contain non-empty namespace and table components"
+            )
+        return components[:-1]
 
-    def ensure_namespace(self, namespace: str) -> None:
-        """Create *namespace* once if it is not already present."""
-        if (namespace,) not in self._catalog.list_namespaces():
-            self._catalog.create_namespace(namespace)
+    def ensure_namespace(self, namespace: Namespace) -> None:
+        """Create *namespace* idempotently, including under concurrent initialization."""
+        self._catalog.create_namespace_if_not_exists(namespace)
 
     def ensure_table(self, identifier: str, schema: Any) -> Any:
         """Return an existing table or create it using *schema*."""

--- a/python/src/data_platform_lab/iceberg/store.py
+++ b/python/src/data_platform_lab/iceberg/store.py
@@ -1,0 +1,48 @@
+"""Application-level Iceberg table operations."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+
+class Catalog(Protocol):
+    """Subset of the PyIceberg catalog surface used by the platform."""
+
+    def list_namespaces(self) -> list[tuple[str, ...]]: ...
+
+    def create_namespace(self, namespace: str) -> None: ...
+
+    def create_table_if_not_exists(self, identifier: str, schema: Any) -> Any: ...
+
+    def load_table(self, identifier: str) -> Any: ...
+
+
+class IcebergTableStore:
+    """Create, append to, and scan Iceberg analytical tables."""
+
+    def __init__(self, catalog: Catalog) -> None:
+        self._catalog = catalog
+
+    def ensure_namespace(self, namespace: str) -> None:
+        """Create *namespace* once if it is not already present."""
+        if (namespace,) not in self._catalog.list_namespaces():
+            self._catalog.create_namespace(namespace)
+
+    def ensure_table(self, identifier: str, schema: Any) -> Any:
+        """Return an existing table or create it using *schema*."""
+        namespace, _, _ = identifier.partition(".")
+        if not namespace:
+            raise ValueError("Iceberg identifiers must include a namespace")
+        self.ensure_namespace(namespace)
+        return self._catalog.create_table_if_not_exists(identifier, schema)
+
+    def append(self, identifier: str, table_data: Any) -> None:
+        """Append one Arrow table to an existing Iceberg table."""
+        table = self._catalog.load_table(identifier)
+        table.append(table_data)
+
+    def row_count(self, identifier: str) -> int:
+        """Scan an Iceberg table and return its current row count."""
+        table = self._catalog.load_table(identifier)
+        arrow_table = table.scan().to_arrow()
+        return int(arrow_table.num_rows)

--- a/python/tests/test_iceberg_store.py
+++ b/python/tests/test_iceberg_store.py
@@ -10,12 +10,23 @@ from data_platform_lab.iceberg import IcebergTableStore
 
 
 class FakeArrowTable:
-    num_rows = 3
+    def __init__(self, num_rows: int) -> None:
+        self.num_rows = num_rows
+
+
+class FakePayload:
+    def __init__(self, num_rows: int) -> None:
+        self.num_rows = num_rows
 
 
 class FakeScan:
+    def __init__(self, appended: list[Any]) -> None:
+        self._appended = appended
+
     def to_arrow(self) -> FakeArrowTable:
-        return FakeArrowTable()
+        return FakeArrowTable(
+            sum(int(getattr(payload, "num_rows", 0)) for payload in self._appended)
+        )
 
 
 class FakeTable:
@@ -26,7 +37,7 @@ class FakeTable:
         self.appended.append(table_data)
 
     def scan(self) -> FakeScan:
-        return FakeScan()
+        return FakeScan(self.appended)
 
 
 class FakeCatalog:
@@ -34,11 +45,9 @@ class FakeCatalog:
         self.namespaces: list[tuple[str, ...]] = []
         self.tables: dict[str, FakeTable] = {}
 
-    def list_namespaces(self) -> list[tuple[str, ...]]:
-        return list(self.namespaces)
-
-    def create_namespace(self, namespace: str) -> None:
-        self.namespaces.append((namespace,))
+    def create_namespace_if_not_exists(self, namespace: tuple[str, ...]) -> None:
+        if namespace not in self.namespaces:
+            self.namespaces.append(namespace)
 
     def create_table_if_not_exists(self, identifier: str, schema: Any) -> FakeTable:
         del schema
@@ -59,20 +68,42 @@ def test_iceberg_store_creates_namespace_and_table_once() -> None:
     assert catalog.namespaces == [("analytics",)]
 
 
-def test_iceberg_store_append_and_scan() -> None:
+def test_iceberg_store_supports_nested_namespaces() -> None:
+    catalog = FakeCatalog()
+    store = IcebergTableStore(catalog)
+
+    store.ensure_table("warehouse.analytics.events", object())
+
+    assert catalog.namespaces == [("warehouse", "analytics")]
+
+
+def test_iceberg_store_append_and_scan_reflects_appended_rows() -> None:
     catalog = FakeCatalog()
     store = IcebergTableStore(catalog)
     store.ensure_table("analytics.events", object())
 
-    payload = object()
-    store.append("analytics.events", payload)
+    first = FakePayload(2)
+    second = FakePayload(1)
+    store.append("analytics.events", first)
+    store.append("analytics.events", second)
 
-    assert catalog.tables["analytics.events"].appended == [payload]
+    assert catalog.tables["analytics.events"].appended == [first, second]
     assert store.row_count("analytics.events") == 3
 
 
-def test_iceberg_identifier_requires_namespace() -> None:
+@pytest.mark.parametrize(
+    "identifier",
+    [
+        "events",
+        ".events",
+        "analytics.",
+        "analytics..events",
+        " analytics.events",
+        "analytics.events ",
+    ],
+)
+def test_iceberg_identifier_rejects_malformed_components(identifier: str) -> None:
     store = IcebergTableStore(FakeCatalog())
 
     with pytest.raises(ValueError, match="namespace"):
-        store.ensure_table("events", object())
+        store.ensure_table(identifier, object())

--- a/python/tests/test_iceberg_store.py
+++ b/python/tests/test_iceberg_store.py
@@ -1,0 +1,78 @@
+"""Tests for the application-level Iceberg table boundary."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from data_platform_lab.iceberg import IcebergTableStore
+
+
+class FakeArrowTable:
+    num_rows = 3
+
+
+class FakeScan:
+    def to_arrow(self) -> FakeArrowTable:
+        return FakeArrowTable()
+
+
+class FakeTable:
+    def __init__(self) -> None:
+        self.appended: list[Any] = []
+
+    def append(self, table_data: Any) -> None:
+        self.appended.append(table_data)
+
+    def scan(self) -> FakeScan:
+        return FakeScan()
+
+
+class FakeCatalog:
+    def __init__(self) -> None:
+        self.namespaces: list[tuple[str, ...]] = []
+        self.tables: dict[str, FakeTable] = {}
+
+    def list_namespaces(self) -> list[tuple[str, ...]]:
+        return list(self.namespaces)
+
+    def create_namespace(self, namespace: str) -> None:
+        self.namespaces.append((namespace,))
+
+    def create_table_if_not_exists(self, identifier: str, schema: Any) -> FakeTable:
+        del schema
+        return self.tables.setdefault(identifier, FakeTable())
+
+    def load_table(self, identifier: str) -> FakeTable:
+        return self.tables[identifier]
+
+
+def test_iceberg_store_creates_namespace_and_table_once() -> None:
+    catalog = FakeCatalog()
+    store = IcebergTableStore(catalog)
+
+    first = store.ensure_table("analytics.events", object())
+    second = store.ensure_table("analytics.events", object())
+
+    assert first is second
+    assert catalog.namespaces == [("analytics",)]
+
+
+def test_iceberg_store_append_and_scan() -> None:
+    catalog = FakeCatalog()
+    store = IcebergTableStore(catalog)
+    store.ensure_table("analytics.events", object())
+
+    payload = object()
+    store.append("analytics.events", payload)
+
+    assert catalog.tables["analytics.events"].appended == [payload]
+    assert store.row_count("analytics.events") == 3
+
+
+def test_iceberg_identifier_requires_namespace() -> None:
+    store = IcebergTableStore(FakeCatalog())
+
+    with pytest.raises(ValueError, match="namespace"):
+        store.ensure_table("events", object())


### PR DESCRIPTION
## Summary

Implements Milestone 3 Phase 4 by adding a real Iceberg analytical-table layer on top of the platform services already introduced.

- adds a Python `IcebergTableStore` application boundary
- adds PyIceberg 0.11.1 with Arrow, S3 and PostgreSQL SQL-catalog support
- persists Iceberg catalog metadata in PostgreSQL
- stores Iceberg table data and metadata files in the Garage S3 warehouse
- adds `data-platform-lab iceberg` for an end-to-end table smoke check
- adds a dedicated Iceberg integration workflow using PostgreSQL + Garage
- adds architecture documentation and updates the Milestone 3 platform diagram

## Architecture

```text
Python analytical workflow
  -> IcebergTableStore
  -> PyIceberg
     -> SQL catalog -> PostgreSQL
     -> FileIO -> S3-compatible API -> Garage
```

PostgreSQL is not used as the analytical data store. It persists catalog state; Iceberg data, manifests and metadata files remain in object storage.

## Validation

Unit tests exercise namespace creation, idempotent table creation, append semantics and scans through an injected catalog. The dedicated integration workflow boots PostgreSQL and Garage, creates an Iceberg table, appends an Arrow record and scans it back through PyIceberg.

## Scope

The live Iceberg implementation is Python-only in this phase because PyIceberg is the mature native client. JavaScript remains part of the surrounding platform, but this PR does not introduce a weaker parallel Iceberg implementation.

## Next

After this phase is stable, Milestone 3 moves to the event-broker adapter for the streaming exercise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Iceberg analytical-table layer to the Python platform so workflows can create, append to, and scan tables while keeping table data and metadata files in the Garage S3 warehouse; catalog state now lives in PostgreSQL.

- Adds `IcebergTableStore` and `build_catalog` with idempotent namespace/table creation, append, and row-count scans; identifiers must be strings with a non-empty namespace and table, and malformed ones raise clear errors.
- Adds `pyiceberg` 0.11.1 with Arrow, S3, and PostgreSQL SQL-catalog extras and constrains Python to below 4.0.
- Adds `data-platform-lab iceberg` smoke command and a CI workflow that boots PostgreSQL and Garage for an end-to-end round trip.
- Adds architecture documentation and updates the Milestone 3 diagram and status.

<sup>Written for commit 74a3ab1782f2d08a2c25a0f9176adf74b3b46615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/data-platform-lab/pull/37?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

