### PR TITLE
Add Apache Kafka event broker adapter

### DIFF
--- a/.github/workflows/kafka-integration.yml
+++ b/.github/workflows/kafka-integration.yml
@@ -1,0 +1,59 @@
+name: Kafka Integration
+
+on:
+  push:
+    paths:
+      - "compose.yaml"
+      - "python/pyproject.toml"
+      - "python/src/data_platform_lab/broker/**"
+      - "python/src/data_platform_lab/cli/main.py"
+      - ".github/workflows/kafka-integration.yml"
+  pull_request:
+    paths:
+      - "compose.yaml"
+      - "python/pyproject.toml"
+      - "python/src/data_platform_lab/broker/**"
+      - "python/src/data_platform_lab/cli/main.py"
+      - ".github/workflows/kafka-integration.yml"
+
+jobs:
+  kafka:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Start Kafka
+        run: docker compose up -d --wait kafka
+      - name: Create smoke topic
+        run: >-
+          docker compose exec -T kafka
+          /opt/kafka/bin/kafka-topics.sh
+          --bootstrap-server localhost:9092
+          --create
+          --if-not-exists
+          --topic data-platform-lab-smoke
+          --partitions 1
+          --replication-factor 1
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install Poetry
+        run: pipx install poetry
+      - name: Install Python dependencies
+        working-directory: python
+        run: poetry install --no-interaction
+      - name: Kafka publish/consume round trip
+        working-directory: python
+        run: poetry run data-platform-lab broker
+      - name: Describe smoke topic
+        run: >-
+          docker compose exec -T kafka
+          /opt/kafka/bin/kafka-topics.sh
+          --bootstrap-server localhost:9092
+          --describe
+          --topic data-platform-lab-smoke
+      - name: Diagnostics
+        if: failure()
+        run: docker compose logs kafka
+      - name: Stop services
+        if: always()
+        run: docker compose down -v

--- a/compose.yaml
+++ b/compose.yaml
@@ -35,6 +35,21 @@ services:
       timeout: 3s
       retries: 20
 
+  kafka:
+    image: apache/kafka:4.3.1
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:9092:9092"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
 volumes:
   garage-meta:
   garage-data:

--- a/docs/kafka-event-broker.md
+++ b/docs/kafka-event-broker.md
@@ -1,0 +1,38 @@
+# Kafka event broker
+
+Milestone 3 Phase 5 adds a transport boundary for durable event delivery without moving event-time or validation semantics into the broker adapter.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Workflow[Streaming workflow] --> Contract[EventBroker]
+    Contract --> Adapter[KafkaEventBroker]
+    Adapter --> Client[confluent-kafka 2.15.0]
+    Client --> Kafka[(Apache Kafka 4.3.1)]
+```
+
+The contract transports opaque byte payloads plus optional byte keys. JSON decoding, validation, deduplication, watermarking, lateness classification, and downstream persistence remain application responsibilities.
+
+## Local validation
+
+Start Kafka and run the smoke command:
+
+```bash
+docker compose up -d --wait kafka
+docker compose exec -T kafka /opt/kafka/bin/kafka-topics.sh \
+  --bootstrap-server localhost:9092 \
+  --create --if-not-exists \
+  --topic data-platform-lab-smoke \
+  --partitions 1 \
+  --replication-factor 1
+cd python
+poetry install --no-interaction
+poetry run data-platform-lab broker
+```
+
+The smoke publishes a keyed JSON payload, consumes it through a fresh consumer group using `auto.offset.reset=earliest`, and verifies that both key and value round-trip unchanged.
+
+## Scope
+
+This phase proves the broker transport contract. Phase 6 will compose Kafka ingestion with the existing sensor-event processor, PostgreSQL run metadata, Garage object storage, and Iceberg analytical output into an end-to-end failure/recovery scenario.

--- a/docs/milestone-m3.md
+++ b/docs/milestone-m3.md
@@ -17,6 +17,7 @@ flowchart LR
     PY --> R[RunStore]
     JS --> R
     PY --> I[IcebergTableStore]
+    PY --> E[EventBroker]
     B --> Local[LocalBlobStore]
     B --> S3[S3BlobStore]
     S3 --> Garage[(Garage S3)]
@@ -25,6 +26,8 @@ flowchart LR
     I --> PI[PyIceberg]
     PI --> DB
     PI --> Garage
+    E --> K[KafkaEventBroker]
+    K --> Kafka[(Apache Kafka 4.3.1)]
 ```
 
 ## Sequence
@@ -32,10 +35,10 @@ flowchart LR
 1. storage and unified-command boundaries — complete;
 2. S3-compatible storage and Garage integration — complete;
 3. PostgreSQL-backed run/metadata store — complete;
-4. Iceberg analytical tables over object storage — in progress;
-5. event-broker adapter for streaming;
+4. Iceberg analytical tables over object storage — complete;
+5. event-broker adapter for streaming — in progress;
 6. end-to-end platform failure/recovery demo.
 
-Phase 3 reuses the existing observability `RunMetadata` shape. Phase 4 adds a PyIceberg SQL catalog in PostgreSQL while keeping Iceberg table data and metadata files in the S3-compatible Garage warehouse.
+Phase 3 reuses the existing observability `RunMetadata` shape. Phase 4 adds a PyIceberg SQL catalog in PostgreSQL while keeping Iceberg table data and metadata files in the S3-compatible Garage warehouse. Phase 5 adds a byte-oriented `EventBroker` contract with a real Apache Kafka adapter; event decoding and event-time semantics remain above the transport boundary.
 
 See [PostgreSQL run metadata](postgres-run-metadata.md) for the operational metadata layer and [Iceberg analytical tables](iceberg-analytical-tables.md) for the analytical-table architecture and local validation flow.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -10,6 +10,7 @@ packages = [{ include = "data_platform_lab", from = "src" }]
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"
 boto3 = ">=1.40,<2.0"
+confluent-kafka = "2.15.0"
 psycopg = {version = ">=3.2,<4.0", extras = ["binary"]}
 pyiceberg = {version = "0.11.1", extras = ["pyarrow", "s3fs", "sql-postgres"]}
 

--- a/python/src/data_platform_lab/broker/__init__.py
+++ b/python/src/data_platform_lab/broker/__init__.py
@@ -1,0 +1,6 @@
+"""Event-broker contracts and Kafka adapter."""
+
+from data_platform_lab.broker.kafka import KafkaEventBroker
+from data_platform_lab.broker.store import BrokerMessage, EventBroker
+
+__all__ = ["BrokerMessage", "EventBroker", "KafkaEventBroker"]

--- a/python/src/data_platform_lab/broker/cli.py
+++ b/python/src/data_platform_lab/broker/cli.py
@@ -1,0 +1,52 @@
+"""Wire-level smoke command for the local Kafka broker."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from uuid import uuid4
+
+from data_platform_lab.broker import KafkaEventBroker
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Verify Kafka publish/consume round trip.")
+    parser.add_argument(
+        "--bootstrap-servers",
+        default=os.getenv("DPL_KAFKA_BOOTSTRAP_SERVERS", "localhost:9092"),
+    )
+    parser.add_argument("--topic", default="data-platform-lab-smoke")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Publish and consume one deterministic JSON message through Kafka."""
+    args = _build_parser().parse_args(argv)
+    group_id = f"data-platform-lab-smoke-{uuid4()}"
+    payload = json.dumps(
+        {"event_id": "broker-smoke", "value": 1.0},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+    broker = KafkaEventBroker(args.bootstrap_servers)
+    try:
+        broker.publish(args.topic, payload, key=b"broker-smoke")
+        message = broker.consume_one(args.topic, group_id, timeout_seconds=15.0)
+        if message is None:
+            raise RuntimeError("Kafka smoke check timed out waiting for the published message")
+        if message.value != payload or message.key != b"broker-smoke":
+            raise RuntimeError("Kafka smoke check returned an unexpected message")
+
+        print("=== Kafka Broker Smoke Check ===")
+        print(f"Topic     : {message.topic}")
+        print(f"Partition : {message.partition}")
+        print(f"Offset    : {message.offset}")
+        print("Round trip: ok")
+    finally:
+        broker.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/data_platform_lab/broker/kafka.py
+++ b/python/src/data_platform_lab/broker/kafka.py
@@ -1,0 +1,104 @@
+"""Kafka implementation of the event-broker boundary."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+from data_platform_lab.broker.store import BrokerMessage
+
+
+class KafkaEventBroker:
+    """Publish and consume messages through Apache Kafka."""
+
+    def __init__(self, bootstrap_servers: str) -> None:
+        if not bootstrap_servers.strip():
+            raise ValueError("bootstrap_servers must not be empty")
+
+        try:
+            kafka = import_module("confluent_kafka")
+        except ModuleNotFoundError as exc:
+            raise RuntimeError("confluent-kafka is required for Kafka broker support") from exc
+
+        producer_factory = getattr(kafka, "Producer", None)
+        consumer_factory = getattr(kafka, "Consumer", None)
+        if not callable(producer_factory) or not callable(consumer_factory):
+            raise RuntimeError("confluent-kafka does not expose Producer and Consumer")
+
+        self._producer = producer_factory({"bootstrap.servers": bootstrap_servers})
+        self._consumer_factory = consumer_factory
+        self._bootstrap_servers = bootstrap_servers
+        self._consumer: Any | None = None
+
+    def publish(self, topic: str, value: bytes, key: bytes | None = None) -> None:
+        """Publish one message and synchronously confirm broker delivery."""
+        if not topic.strip():
+            raise ValueError("topic must not be empty")
+        if not isinstance(value, bytes):
+            raise TypeError("value must be bytes")
+
+        delivery_error: list[Exception] = []
+
+        def delivered(error: Any, _message: Any) -> None:
+            if error is not None:
+                delivery_error.append(RuntimeError(str(error)))
+
+        self._producer.produce(topic=topic, value=value, key=key, callback=delivered)
+        remaining = self._producer.flush(10.0)
+        if remaining:
+            raise TimeoutError(f"Kafka delivery timed out with {remaining} message(s) pending")
+        if delivery_error:
+            raise delivery_error[0]
+
+    def consume_one(
+        self,
+        topic: str,
+        group_id: str,
+        timeout_seconds: float = 10.0,
+    ) -> BrokerMessage | None:
+        """Consume one message from *topic* using a fresh group subscription."""
+        if not topic.strip():
+            raise ValueError("topic must not be empty")
+        if not group_id.strip():
+            raise ValueError("group_id must not be empty")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+
+        self._close_consumer()
+        consumer = self._consumer_factory(
+            {
+                "bootstrap.servers": self._bootstrap_servers,
+                "group.id": group_id,
+                "auto.offset.reset": "earliest",
+                "enable.auto.commit": False,
+            }
+        )
+        self._consumer = consumer
+        consumer.subscribe([topic])
+        message = consumer.poll(timeout_seconds)
+        if message is None:
+            return None
+        error = message.error()
+        if error is not None:
+            raise RuntimeError(f"Kafka consume failed: {error}")
+
+        value = message.value()
+        if value is None:
+            raise RuntimeError("Kafka message payload is unexpectedly null")
+        return BrokerMessage(
+            topic=str(message.topic()),
+            partition=int(message.partition()),
+            offset=int(message.offset()),
+            key=message.key(),
+            value=bytes(value),
+        )
+
+    def close(self) -> None:
+        """Flush producer state and close any active consumer."""
+        self._producer.flush(10.0)
+        self._close_consumer()
+
+    def _close_consumer(self) -> None:
+        if self._consumer is not None:
+            self._consumer.close()
+            self._consumer = None

--- a/python/src/data_platform_lab/broker/store.py
+++ b/python/src/data_platform_lab/broker/store.py
@@ -1,0 +1,36 @@
+"""Application-level event-broker contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class BrokerMessage:
+    """One message read from an event broker."""
+
+    topic: str
+    partition: int
+    offset: int
+    key: bytes | None
+    value: bytes
+
+
+@runtime_checkable
+class EventBroker(Protocol):
+    """Minimal publish/consume boundary used by the local platform."""
+
+    def publish(self, topic: str, value: bytes, key: bytes | None = None) -> None:
+        """Publish one message and wait for delivery confirmation."""
+
+    def consume_one(
+        self,
+        topic: str,
+        group_id: str,
+        timeout_seconds: float = 10.0,
+    ) -> BrokerMessage | None:
+        """Return one message or ``None`` when the timeout expires."""
+
+    def close(self) -> None:
+        """Flush producer state and release consumer resources."""

--- a/python/src/data_platform_lab/cli/main.py
+++ b/python/src/data_platform_lab/cli/main.py
@@ -6,6 +6,7 @@ import argparse
 from collections.abc import Callable
 
 from data_platform_lab.benchmark.cli import main as benchmark_main
+from data_platform_lab.broker.cli import main as broker_main
 from data_platform_lab.iceberg.cli import main as iceberg_main
 from data_platform_lab.metadata.cli import main as metadata_main
 from data_platform_lab.storage.cli import main as storage_main
@@ -16,6 +17,7 @@ CommandHandler = Callable[[list[str] | None], None]
 
 _COMMANDS: dict[str, CommandHandler] = {
     "benchmark": benchmark_main,
+    "broker": broker_main,
     "iceberg": iceberg_main,
     "metadata": metadata_main,
     "storage": storage_main,

--- a/python/tests/test_broker_kafka.py
+++ b/python/tests/test_broker_kafka.py
@@ -1,0 +1,98 @@
+"""Tests for the Kafka event-broker adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from data_platform_lab.broker import BrokerMessage, EventBroker, KafkaEventBroker
+
+
+class FakeMessage:
+    def __init__(self, value: bytes = b"payload", key: bytes | None = b"key") -> None:
+        self._value = value
+        self._key = key
+
+    def error(self) -> None:
+        return None
+
+    def topic(self) -> str:
+        return "events"
+
+    def partition(self) -> int:
+        return 0
+
+    def offset(self) -> int:
+        return 7
+
+    def key(self) -> bytes | None:
+        return self._key
+
+    def value(self) -> bytes:
+        return self._value
+
+
+class FakeProducer:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, bytes, bytes | None]] = []
+
+    def produce(self, *, topic: str, value: bytes, key: bytes | None, callback: Any) -> None:
+        self.calls.append((topic, value, key))
+        callback(None, FakeMessage(value=value, key=key))
+
+    def flush(self, _timeout: float) -> int:
+        return 0
+
+
+class FakeConsumer:
+    def __init__(self, message: FakeMessage | None = None) -> None:
+        self.message = message or FakeMessage()
+        self.subscriptions: list[list[str]] = []
+        self.closed = False
+
+    def subscribe(self, topics: list[str]) -> None:
+        self.subscriptions.append(topics)
+
+    def poll(self, _timeout: float) -> FakeMessage:
+        return self.message
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_event_broker_contract_is_runtime_checkable() -> None:
+    class DummyBroker:
+        def publish(self, topic: str, value: bytes, key: bytes | None = None) -> None:
+            del topic, value, key
+
+        def consume_one(
+            self, topic: str, group_id: str, timeout_seconds: float = 10.0
+        ) -> BrokerMessage | None:
+            del topic, group_id, timeout_seconds
+            return None
+
+        def close(self) -> None:
+            return None
+
+    assert isinstance(DummyBroker(), EventBroker)
+
+
+def test_kafka_adapter_validates_inputs_without_connecting() -> None:
+    broker = object.__new__(KafkaEventBroker)
+
+    with pytest.raises(ValueError, match="topic"):
+        KafkaEventBroker.publish(broker, "", b"payload")
+
+    with pytest.raises(TypeError, match="bytes"):
+        KafkaEventBroker.publish(broker, "events", "payload")  # type: ignore[arg-type]
+
+
+def test_broker_message_is_immutable_value_object() -> None:
+    message = BrokerMessage("events", 0, 7, b"key", b"payload")
+
+    assert message.topic == "events"
+    assert message.partition == 0
+    assert message.offset == 7
+    assert message.key == b"key"
+    assert message.value == b"payload"


### PR DESCRIPTION
## Summary

Implements Milestone 3 Phase 5 by adding a real event-broker boundary backed by Apache Kafka.

- adds a typed Python `EventBroker` contract with opaque byte payloads and optional byte keys
- adds `KafkaEventBroker` using `confluent-kafka` 2.15.0
- adds Apache Kafka 4.3.1 to the local Compose stack
- adds `data-platform-lab broker` for a real publish/consume round trip
- adds a dedicated Kafka Integration workflow
- adds unit coverage for the broker contract and input validation
- updates Milestone 3 architecture/status and adds broker documentation

## Architecture

```text
Streaming workflow
  -> EventBroker
  -> KafkaEventBroker
  -> confluent-kafka
  -> Apache Kafka 4.3.1
```

The broker transports bytes only. JSON decoding, validation, deduplication, watermarking, lateness handling, and persistence remain above the transport boundary.

## Validation

The integration workflow starts the official Kafka image, creates a one-partition smoke topic, publishes a keyed JSON payload through `KafkaEventBroker`, consumes it with a fresh consumer group, and verifies key/value equality.

## Scope

This phase proves broker transport. The existing streaming processor is intentionally unchanged; Milestone 3 Phase 6 will compose Kafka ingestion with PostgreSQL run metadata, Garage object storage, Iceberg analytical tables, and explicit failure/recovery behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an event-broker transport boundary backed by Apache Kafka, so streaming workloads can publish and consume durable byte messages. The broker carries opaque byte payloads with optional byte keys; JSON decoding, validation, deduplication, watermarking, lateness handling, and persistence stay above the transport boundary.

- Adds a typed `EventBroker` protocol with a `KafkaEventBroker` implementation via `confluent-kafka` 2.15.0.
- Adds Apache Kafka 4.3.1 to the local Compose stack and a `data-platform-lab broker` smoke command that publishes and consumes one keyed message over a fresh consumer group.
- Adds a Kafka integration workflow that runs the round trip against a live Kafka container.
- Adds unit coverage for the broker contract, input validation, and the immutable `BrokerMessage` shape.
- Updates Milestone 3 status and adds broker documentation.

**Scope**
The existing streaming processor is intentionally unchanged. Phase 6 will compose Kafka ingestion with PostgreSQL run metadata, Garage object storage, and Iceberg analytical tables into an end-to-end scenario.

<sup>Written for commit 2be8d9f6107cd5bc481d23764bb29aa4970c6c91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/data-platform-lab/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

