### PR TITLE
Add end-to-end platform failure recovery

### DIFF
--- a/.github/workflows/platform-recovery.yml
+++ b/.github/workflows/platform-recovery.yml
@@ -1,0 +1,91 @@
+name: Platform Recovery
+
+on:
+  push:
+    paths:
+      - "compose.yaml"
+      - "infra/garage/**"
+      - "sql/platform/**"
+      - "python/pyproject.toml"
+      - "python/src/data_platform_lab/broker/**"
+      - "python/src/data_platform_lab/iceberg/**"
+      - "python/src/data_platform_lab/metadata/**"
+      - "python/src/data_platform_lab/recovery/**"
+      - "python/src/data_platform_lab/storage/**"
+      - "python/src/data_platform_lab/streaming/**"
+      - "python/src/data_platform_lab/cli/main.py"
+      - ".github/workflows/platform-recovery.yml"
+  pull_request:
+    paths:
+      - "compose.yaml"
+      - "infra/garage/**"
+      - "sql/platform/**"
+      - "python/pyproject.toml"
+      - "python/src/data_platform_lab/broker/**"
+      - "python/src/data_platform_lab/iceberg/**"
+      - "python/src/data_platform_lab/metadata/**"
+      - "python/src/data_platform_lab/recovery/**"
+      - "python/src/data_platform_lab/storage/**"
+      - "python/src/data_platform_lab/streaming/**"
+      - "python/src/data_platform_lab/cli/main.py"
+      - ".github/workflows/platform-recovery.yml"
+
+jobs:
+  recovery:
+    name: Kafka + PostgreSQL + Garage + Iceberg recovery
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start PostgreSQL and Kafka
+        run: docker compose up -d --wait postgres kafka
+
+      - name: Start Garage
+        run: sh infra/garage/bootstrap.sh
+
+      - name: Create recovery topic
+        run: >-
+          docker compose exec -T kafka
+          /opt/kafka/bin/kafka-topics.sh
+          --bootstrap-server localhost:9092
+          --create
+          --if-not-exists
+          --topic data-platform-lab-recovery-smoke
+          --partitions 1
+          --replication-factor 1
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install Python dependencies
+        working-directory: python
+        run: poetry install --no-interaction
+
+      - name: Run injected failure and recovery
+        working-directory: python
+        shell: bash
+        run: |
+          set -a
+          source ../infra/garage/dev.env
+          set +a
+          poetry run data-platform-lab recovery --topic data-platform-lab-recovery-smoke
+
+      - name: Inspect final run metadata
+        run: |
+          docker compose exec -T postgres psql -U data_platform_lab -d data_platform_lab \
+            -c "SELECT pipeline_name, run_id, status, rows_written, files_processed FROM pipeline_runs WHERE pipeline_name='broker_to_iceberg';"
+
+      - name: Diagnostics
+        if: failure()
+        run: |
+          docker compose logs postgres
+          docker compose logs garage
+          docker compose logs kafka
+
+      - name: Stop services
+        if: always()
+        run: docker compose down -v

--- a/docs/milestone-m3.md
+++ b/docs/milestone-m3.md
@@ -18,6 +18,7 @@ flowchart LR
     JS --> R
     PY --> I[IcebergTableStore]
     PY --> E[EventBroker]
+    PY --> RC[RecoverableIngestionPipeline]
     B --> Local[LocalBlobStore]
     B --> S3[S3BlobStore]
     S3 --> Garage[(Garage S3)]
@@ -28,6 +29,36 @@ flowchart LR
     PI --> Garage
     E --> K[KafkaEventBroker]
     K --> Kafka[(Apache Kafka 4.3.1)]
+    RC --> E
+    RC --> R
+    RC --> B
+    RC --> I
+```
+
+## Recovery sequence
+
+```mermaid
+sequenceDiagram
+    participant K as Kafka
+    participant C as Recovery coordinator
+    participant P as PostgreSQL
+    participant S as Garage S3
+    participant I as Iceberg
+
+    K->>C: consume uncommitted message
+    C->>P: save running run_id
+    C->>S: put deterministic raw object
+    C->>I: append ingestion_id if missing
+    Note over C,I: injected crash may occur here
+    C->>P: save success
+    C->>K: commit offset + 1
+
+    Note over K,C: after a pre-ack crash, Kafka replays the same position
+    K->>C: replay same topic/partition/offset
+    C->>S: replace same raw object key
+    C->>I: ingestion_id already present; skip append
+    C->>P: save success
+    C->>K: commit offset + 1
 ```
 
 ## Sequence
@@ -36,9 +67,9 @@ flowchart LR
 2. S3-compatible storage and Garage integration — complete;
 3. PostgreSQL-backed run/metadata store — complete;
 4. Iceberg analytical tables over object storage — complete;
-5. event-broker adapter for streaming — in progress;
-6. end-to-end platform failure/recovery demo.
+5. event-broker adapter for streaming — complete;
+6. end-to-end platform failure/recovery demo — in progress.
 
-Phase 3 reuses the existing observability `RunMetadata` shape. Phase 4 adds a PyIceberg SQL catalog in PostgreSQL while keeping Iceberg table data and metadata files in the S3-compatible Garage warehouse. Phase 5 adds a byte-oriented `EventBroker` contract with a real Apache Kafka adapter; event decoding and event-time semantics remain above the transport boundary.
+Phase 3 reuses the existing observability `RunMetadata` shape. Phase 4 adds a PyIceberg SQL catalog in PostgreSQL while keeping Iceberg table data and metadata files in the S3-compatible Garage warehouse. Phase 5 adds a byte-oriented `EventBroker` contract with a real Apache Kafka adapter; event decoding and event-time semantics remain above the transport boundary. Phase 6 composes those boundaries with deterministic broker-position identities, explicit post-Iceberg failure injection, replay reconciliation, and acknowledgement only after durable recovery.
 
-See [PostgreSQL run metadata](postgres-run-metadata.md) for the operational metadata layer and [Iceberg analytical tables](iceberg-analytical-tables.md) for the analytical-table architecture and local validation flow.
+See [PostgreSQL run metadata](postgres-run-metadata.md), [Iceberg analytical tables](iceberg-analytical-tables.md), [Apache Kafka event broker](kafka-event-broker.md), and [Platform failure and recovery](platform-recovery.md) for the individual contracts and acceptance flows.

--- a/docs/platform-recovery.md
+++ b/docs/platform-recovery.md
@@ -1,0 +1,73 @@
+# Platform Failure and Recovery
+
+Milestone 3 ends with one deliberate failure/recovery path across the local platform:
+
+```text
+Kafka
+  -> recoverable ingestion coordinator
+     -> PostgreSQL run metadata
+     -> Garage raw object
+     -> Iceberg analytical table
+  -> Kafka acknowledgement
+```
+
+## Recovery identity
+
+Every consumed broker position has a deterministic ingestion identity:
+
+```text
+{topic}:{partition}:{offset}
+```
+
+The same identity is reused as the PostgreSQL `run_id` and is written into the Iceberg row as `ingestion_id`. The raw payload uses the deterministic object key:
+
+```text
+ingestion/{topic}/{partition}/{offset}.json
+```
+
+This gives replay a stable cross-system referent without introducing a distributed transaction.
+
+## Commit order
+
+The coordinator processes one message in this order:
+
+1. persist a `running` run snapshot in PostgreSQL;
+2. write the original message bytes to Garage under the deterministic object key;
+3. validate and transform the sensor event;
+4. ensure the Iceberg analytical table exists;
+5. scan the Iceberg `ingestion_id` column and append only if this broker position is absent;
+6. persist a `success` run snapshot in PostgreSQL;
+7. synchronously commit Kafka offset `offset + 1`.
+
+Kafka acknowledgement is intentionally last. A crash before acknowledgement leaves the message eligible for replay.
+
+## Post-Iceberg crash window
+
+The acceptance test deliberately fails after the Iceberg append but before final PostgreSQL success metadata and Kafka acknowledgement.
+
+On replay:
+
+- Kafka returns the same uncommitted position;
+- Garage receives the same raw-object key, so the raw payload is replaced idempotently;
+- PostgreSQL reuses the same `(pipeline_name, run_id)` row;
+- Iceberg is scanned for the deterministic `ingestion_id` and therefore does not receive a duplicate append;
+- the run is then marked successful;
+- only then is the Kafka position committed.
+
+The expected analytical row count after failure plus replay is exactly one.
+
+## Semantics
+
+This is an **at-least-once broker delivery model with deterministic reconciliation**. It is not a distributed exactly-once transaction across Kafka, PostgreSQL, S3 and Iceberg.
+
+The reconciliation scan is deliberately simple and suitable for this local lab. A production platform with large tables would replace the full-column scan with a more scalable ingestion ledger, merge/upsert strategy, or engine-native transactional design.
+
+## Validation
+
+The `Platform Recovery` GitHub Actions workflow boots all four services, publishes one sensor event, injects the post-Iceberg failure, replays the message, and checks:
+
+- the same Kafka position is replayed;
+- no second Iceberg row is appended;
+- the raw Garage object exists;
+- PostgreSQL ends with `status = success`;
+- Kafka is acknowledged only after recovery completes.

--- a/python/src/data_platform_lab/broker/kafka.py
+++ b/python/src/data_platform_lab/broker/kafka.py
@@ -22,11 +22,18 @@ class KafkaEventBroker:
 
         producer_factory = getattr(kafka, "Producer", None)
         consumer_factory = getattr(kafka, "Consumer", None)
-        if not callable(producer_factory) or not callable(consumer_factory):
-            raise RuntimeError("confluent-kafka does not expose Producer and Consumer")
+        topic_partition_factory = getattr(kafka, "TopicPartition", None)
+        if not all(
+            callable(factory)
+            for factory in (producer_factory, consumer_factory, topic_partition_factory)
+        ):
+            raise RuntimeError(
+                "confluent-kafka does not expose Producer, Consumer, and TopicPartition"
+            )
 
         self._producer = producer_factory({"bootstrap.servers": bootstrap_servers})
         self._consumer_factory = consumer_factory
+        self._topic_partition_factory = topic_partition_factory
         self._bootstrap_servers = bootstrap_servers
         self._consumer: Any | None = None
 
@@ -56,7 +63,7 @@ class KafkaEventBroker:
         group_id: str,
         timeout_seconds: float = 10.0,
     ) -> BrokerMessage | None:
-        """Consume one message from *topic* using a fresh group subscription."""
+        """Consume one message from *topic* without committing its offset."""
         if not topic.strip():
             raise ValueError("topic must not be empty")
         if not group_id.strip():
@@ -92,6 +99,17 @@ class KafkaEventBroker:
             key=message.key(),
             value=bytes(value),
         )
+
+    def acknowledge(self, message: BrokerMessage) -> None:
+        """Synchronously commit the position immediately after *message*."""
+        if self._consumer is None:
+            raise RuntimeError("cannot acknowledge without an active Kafka consumer")
+        if not isinstance(message, BrokerMessage):
+            raise TypeError("message must be a BrokerMessage")
+
+        next_offset = message.offset + 1
+        position = self._topic_partition_factory(message.topic, message.partition, next_offset)
+        self._consumer.commit(offsets=[position], asynchronous=False)
 
     def close(self) -> None:
         """Flush producer state and close any active consumer."""

--- a/python/src/data_platform_lab/broker/store.py
+++ b/python/src/data_platform_lab/broker/store.py
@@ -32,5 +32,8 @@ class EventBroker(Protocol):
     ) -> BrokerMessage | None:
         """Return one message or ``None`` when the timeout expires."""
 
+    def acknowledge(self, message: BrokerMessage) -> None:
+        """Commit the consumed message position after durable processing succeeds."""
+
     def close(self) -> None:
         """Flush producer state and release consumer resources."""

--- a/python/src/data_platform_lab/cli/main.py
+++ b/python/src/data_platform_lab/cli/main.py
@@ -9,6 +9,7 @@ from data_platform_lab.benchmark.cli import main as benchmark_main
 from data_platform_lab.broker.cli import main as broker_main
 from data_platform_lab.iceberg.cli import main as iceberg_main
 from data_platform_lab.metadata.cli import main as metadata_main
+from data_platform_lab.recovery.cli import main as recovery_main
 from data_platform_lab.storage.cli import main as storage_main
 from data_platform_lab.streaming.cli import main as streaming_main
 from data_platform_lab.warehouse.cli import main as warehouse_main
@@ -20,6 +21,7 @@ _COMMANDS: dict[str, CommandHandler] = {
     "broker": broker_main,
     "iceberg": iceberg_main,
     "metadata": metadata_main,
+    "recovery": recovery_main,
     "storage": storage_main,
     "stream": streaming_main,
     "warehouse": warehouse_main,

--- a/python/src/data_platform_lab/iceberg/store.py
+++ b/python/src/data_platform_lab/iceberg/store.py
@@ -18,7 +18,7 @@ class Catalog(Protocol):
 
 
 class IcebergTableStore:
-    """Create, append to, and scan Iceberg analytical tables."""
+    """Create, append to, scan, and reconcile Iceberg analytical tables."""
 
     def __init__(self, catalog: Catalog) -> None:
         self._catalog = catalog
@@ -53,6 +53,25 @@ class IcebergTableStore:
         self._namespace(identifier)
         table = self._catalog.load_table(identifier)
         table.append(table_data)
+
+    def contains_value(self, identifier: str, field_name: str, value: object) -> bool:
+        """Return whether *field_name* already contains *value* in the table.
+
+        This intentionally uses a full Arrow scan. It is a simple reconciliation
+        primitive for the local recovery demo, not a substitute for a production
+        index or merge-on-read strategy.
+        """
+        self._namespace(identifier)
+        if not isinstance(field_name, str) or not field_name.strip():
+            raise ValueError("field_name must not be empty")
+
+        table = self._catalog.load_table(identifier)
+        arrow_table = table.scan(selected_fields=(field_name,)).to_arrow()
+        try:
+            column = arrow_table.column(field_name)
+        except (KeyError, ValueError) as exc:
+            raise ValueError(f"Iceberg table does not contain field: {field_name}") from exc
+        return value in column.to_pylist()
 
     def row_count(self, identifier: str) -> int:
         """Scan an Iceberg table and return its current row count."""

--- a/python/src/data_platform_lab/recovery/__init__.py
+++ b/python/src/data_platform_lab/recovery/__init__.py
@@ -1,0 +1,5 @@
+"""End-to-end recovery orchestration for the local platform."""
+
+from data_platform_lab.recovery.pipeline import RecoveryResult, RecoverableIngestionPipeline
+
+__all__ = ["RecoverableIngestionPipeline", "RecoveryResult"]

--- a/python/src/data_platform_lab/recovery/__init__.py
+++ b/python/src/data_platform_lab/recovery/__init__.py
@@ -1,5 +1,5 @@
 """End-to-end recovery orchestration for the local platform."""
 
-from data_platform_lab.recovery.pipeline import RecoveryResult, RecoverableIngestionPipeline
+from data_platform_lab.recovery.pipeline import RecoverableIngestionPipeline, RecoveryResult
 
 __all__ = ["RecoverableIngestionPipeline", "RecoveryResult"]

--- a/python/src/data_platform_lab/recovery/cli.py
+++ b/python/src/data_platform_lab/recovery/cli.py
@@ -1,0 +1,139 @@
+"""End-to-end local platform failure/recovery smoke command."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+
+from data_platform_lab.broker import KafkaEventBroker
+from data_platform_lab.iceberg import IcebergCatalogConfig, IcebergTableStore, build_catalog
+from data_platform_lab.metadata import PostgresRunStore
+from data_platform_lab.recovery import RecoverableIngestionPipeline
+from data_platform_lab.storage import S3BlobStore
+
+_DEFAULT_DSN = "postgresql://data_platform_lab:data_platform_lab@localhost:5432/data_platform_lab"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Prove broker-to-Iceberg recovery after an injected post-commit failure."
+    )
+    parser.add_argument("--topic", default="data-platform-lab-recovery")
+    parser.add_argument("--group-id", default="data-platform-lab-recovery-smoke")
+    parser.add_argument("--bootstrap-servers", default="localhost:9092")
+    parser.add_argument("--postgres-dsn", default=os.getenv("DPL_POSTGRES_DSN", _DEFAULT_DSN))
+    parser.add_argument(
+        "--warehouse",
+        default=os.getenv("DPL_ICEBERG_WAREHOUSE", "s3://data-platform-lab/iceberg"),
+    )
+    parser.add_argument(
+        "--s3-endpoint",
+        default=os.getenv("DPL_S3_ENDPOINT_URL", "http://localhost:3900"),
+    )
+    parser.add_argument("--table", default="analytics.sensor_events")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Run one deliberate failure and prove replay completes without duplication."""
+    args = _build_parser().parse_args(argv)
+    access_key = os.getenv("AWS_ACCESS_KEY_ID")
+    secret_key = os.getenv("AWS_SECRET_ACCESS_KEY")
+    if not access_key or not secret_key:
+        raise RuntimeError("AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are required")
+
+    broker = KafkaEventBroker(args.bootstrap_servers)
+    run_store = PostgresRunStore.connect(args.postgres_dsn)
+    blob_store = S3BlobStore.from_boto3(
+        bucket="data-platform-lab",
+        endpoint_url=args.s3_endpoint,
+        region_name=os.getenv("AWS_DEFAULT_REGION", "garage"),
+        access_key_id=access_key,
+        secret_access_key=secret_key,
+        key_prefix="recovery",
+    )
+    iceberg_store = IcebergTableStore(
+        build_catalog(
+            IcebergCatalogConfig(
+                catalog_name="recovery",
+                postgres_dsn=args.postgres_dsn,
+                warehouse=args.warehouse,
+                s3_endpoint=args.s3_endpoint,
+                s3_access_key_id=access_key,
+                s3_secret_access_key=secret_key,
+                s3_region=os.getenv("AWS_DEFAULT_REGION", "garage"),
+            )
+        )
+    )
+    pipeline = RecoverableIngestionPipeline(
+        broker=broker,
+        run_store=run_store,
+        blob_store=blob_store,
+        iceberg_store=iceberg_store,
+        table_identifier=args.table,
+    )
+
+    payload = json.dumps(
+        {
+            "sensor_id": "recovery-sensor",
+            "type": "temperature",
+            "value": 22.25,
+            "unit": "C",
+            "location": "platform-lab",
+            "timestamp": "2026-09-01T12:00:00+00:00",
+        },
+        separators=(",", ":"),
+    ).encode()
+
+    try:
+        broker.publish(args.topic, payload, key=b"recovery-sensor")
+        first = broker.consume_one(args.topic, args.group_id)
+        if first is None:
+            raise RuntimeError("recovery smoke could not consume the published message")
+
+        try:
+            pipeline.process(first, fail_after_iceberg=True)
+        except RuntimeError as exc:
+            if "injected failure after Iceberg commit" not in str(exc):
+                raise
+        else:
+            raise RuntimeError("recovery smoke expected the injected failure")
+
+        replay = broker.consume_one(args.topic, args.group_id)
+        if replay is None:
+            raise RuntimeError("unacknowledged Kafka message was not replayed")
+        if (replay.topic, replay.partition, replay.offset) != (
+            first.topic,
+            first.partition,
+            first.offset,
+        ):
+            raise RuntimeError("Kafka replay returned a different broker position")
+
+        result = pipeline.process(replay)
+        if result.appended:
+            raise RuntimeError("recovery replay appended a duplicate Iceberg row")
+        if iceberg_store.row_count(args.table) != 1:
+            raise RuntimeError("recovery smoke expected exactly one Iceberg row")
+
+        metadata = run_store.get("broker_to_iceberg", result.ingestion_id)
+        if metadata is None or metadata.status != "success":
+            raise RuntimeError("recovery smoke did not finish with successful run metadata")
+        if not blob_store.exists(result.raw_object_key):
+            raise RuntimeError("recovery smoke raw object is missing from object storage")
+
+        print("=== End-to-End Recovery Smoke ===")
+        print(f"Broker position : {result.ingestion_id}")
+        print(f"Raw object      : recovery/{result.raw_object_key}")
+        print(f"Iceberg table   : {args.table}")
+        print("Iceberg rows    : 1")
+        print("Replay duplicate: no")
+        print("Final status    : success")
+        print("Kafka ack       : committed after durable recovery")
+    finally:
+        broker.close()
+        run_store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/src/data_platform_lab/recovery/pipeline.py
+++ b/python/src/data_platform_lab/recovery/pipeline.py
@@ -1,0 +1,201 @@
+"""Recoverable broker-to-object-storage-to-Iceberg ingestion path."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from importlib import import_module
+from typing import Any
+
+from data_platform_lab.broker import BrokerMessage, EventBroker
+from data_platform_lab.iceberg import IcebergTableStore
+from data_platform_lab.metadata import RunStore
+from data_platform_lab.observability import RunMetadata
+from data_platform_lab.storage import BlobStore
+from data_platform_lab.streaming.processor import parse_event_time, validate_event
+
+_PIPELINE_NAME = "broker_to_iceberg"
+
+
+@dataclass(frozen=True, slots=True)
+class RecoveryResult:
+    """Outcome of processing one broker position."""
+
+    ingestion_id: str
+    raw_object_key: str
+    replayed: bool
+    appended: bool
+
+
+class RecoverableIngestionPipeline:
+    """Persist one broker message durably before acknowledging its offset."""
+
+    def __init__(
+        self,
+        *,
+        broker: EventBroker,
+        run_store: RunStore,
+        blob_store: BlobStore,
+        iceberg_store: IcebergTableStore,
+        table_identifier: str = "analytics.sensor_events",
+    ) -> None:
+        self._broker = broker
+        self._run_store = run_store
+        self._blob_store = blob_store
+        self._iceberg_store = iceberg_store
+        self._table_identifier = table_identifier
+
+    @staticmethod
+    def ingestion_id(message: BrokerMessage) -> str:
+        """Return the deterministic identity for one Kafka position."""
+        return f"{message.topic}:{message.partition}:{message.offset}"
+
+    @staticmethod
+    def raw_object_key(message: BrokerMessage) -> str:
+        """Return the deterministic object key for one broker payload."""
+        return f"ingestion/{message.topic}/{message.partition}/{message.offset}.json"
+
+    def process(
+        self,
+        message: BrokerMessage,
+        *,
+        fail_after_iceberg: bool = False,
+    ) -> RecoveryResult:
+        """Process one message and acknowledge only after durable success.
+
+        ``fail_after_iceberg`` exists solely for the recovery integration test.
+        It simulates a crash after the analytical commit but before final run
+        metadata and Kafka acknowledgement.
+        """
+        ingestion_id = self.ingestion_id(message)
+        raw_key = self.raw_object_key(message)
+        previous = self._run_store.get(_PIPELINE_NAME, ingestion_id)
+
+        if previous is not None and previous.status == "success":
+            self._broker.acknowledge(message)
+            return RecoveryResult(ingestion_id, raw_key, replayed=True, appended=False)
+
+        started_at = datetime.now(UTC)
+        self._run_store.save(
+            RunMetadata(
+                pipeline_name=_PIPELINE_NAME,
+                run_id=ingestion_id,
+                status="running",
+                started_at=started_at.isoformat(),
+                rows_read=1,
+                extra={"raw_object_key": raw_key},
+            )
+        )
+
+        appended = False
+        try:
+            self._blob_store.put_bytes(raw_key, message.value)
+            event = self._decode_event(message.value)
+            schema, batch = self._arrow_batch(ingestion_id, message, event)
+            self._iceberg_store.ensure_table(self._table_identifier, schema)
+
+            if not self._iceberg_store.contains_value(
+                self._table_identifier, "ingestion_id", ingestion_id
+            ):
+                self._iceberg_store.append(self._table_identifier, batch)
+                appended = True
+
+            if fail_after_iceberg:
+                raise RuntimeError("injected failure after Iceberg commit")
+
+            ended_at = datetime.now(UTC)
+            self._run_store.save(
+                RunMetadata(
+                    pipeline_name=_PIPELINE_NAME,
+                    run_id=ingestion_id,
+                    status="success",
+                    started_at=started_at.isoformat(),
+                    ended_at=ended_at.isoformat(),
+                    duration_seconds=(ended_at - started_at).total_seconds(),
+                    rows_read=1,
+                    rows_written=1,
+                    files_processed=1,
+                    extra={
+                        "raw_object_key": raw_key,
+                        "table": self._table_identifier,
+                        "reconciled": not appended,
+                    },
+                )
+            )
+        except Exception as exc:
+            ended_at = datetime.now(UTC)
+            self._run_store.save(
+                RunMetadata(
+                    pipeline_name=_PIPELINE_NAME,
+                    run_id=ingestion_id,
+                    status="failed",
+                    started_at=started_at.isoformat(),
+                    ended_at=ended_at.isoformat(),
+                    duration_seconds=(ended_at - started_at).total_seconds(),
+                    rows_read=1,
+                    rows_written=1 if appended else 0,
+                    files_processed=1 if self._blob_store.exists(raw_key) else 0,
+                    errors=[str(exc)],
+                    extra={"raw_object_key": raw_key, "table": self._table_identifier},
+                )
+            )
+            raise
+
+        self._broker.acknowledge(message)
+        return RecoveryResult(ingestion_id, raw_key, replayed=previous is not None, appended=appended)
+
+    @staticmethod
+    def _decode_event(payload: bytes) -> dict[str, Any]:
+        """Decode and validate one sensor event payload."""
+        try:
+            decoded = json.loads(payload.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise ValueError("broker payload must contain valid UTF-8 JSON") from exc
+        if not isinstance(decoded, dict):
+            raise ValueError("broker payload must decode to a JSON object")
+
+        result = validate_event(decoded)
+        if result.status != "accepted":
+            raise ValueError(result.reason or "invalid sensor event")
+        return decoded
+
+    @staticmethod
+    def _arrow_batch(
+        ingestion_id: str,
+        message: BrokerMessage,
+        event: dict[str, Any],
+    ) -> tuple[Any, Any]:
+        """Build the canonical analytical schema and one-row Arrow batch."""
+        try:
+            pa = import_module("pyarrow")
+        except ModuleNotFoundError as exc:
+            raise RuntimeError("PyArrow is required for recovery ingestion") from exc
+
+        schema = pa.schema(
+            [
+                ("ingestion_id", pa.string()),
+                ("topic", pa.string()),
+                ("partition", pa.int32()),
+                ("offset", pa.int64()),
+                ("sensor_id", pa.string()),
+                ("type", pa.string()),
+                ("value", pa.float64()),
+                ("unit", pa.string()),
+                ("location", pa.string()),
+                ("event_time", pa.timestamp("us", tz="UTC")),
+            ]
+        )
+        row = {
+            "ingestion_id": ingestion_id,
+            "topic": message.topic,
+            "partition": message.partition,
+            "offset": message.offset,
+            "sensor_id": event["sensor_id"],
+            "type": event["type"],
+            "value": float(event["value"]),
+            "unit": event["unit"],
+            "location": event["location"],
+            "event_time": parse_event_time(event["timestamp"]),
+        }
+        return schema, pa.Table.from_pylist([row], schema=schema)

--- a/python/src/data_platform_lab/recovery/pipeline.py
+++ b/python/src/data_platform_lab/recovery/pipeline.py
@@ -145,7 +145,12 @@ class RecoverableIngestionPipeline:
             raise
 
         self._broker.acknowledge(message)
-        return RecoveryResult(ingestion_id, raw_key, replayed=previous is not None, appended=appended)
+        return RecoveryResult(
+            ingestion_id,
+            raw_key,
+            replayed=previous is not None,
+            appended=appended,
+        )
 
     @staticmethod
     def _decode_event(payload: bytes) -> dict[str, Any]:

--- a/python/src/data_platform_lab/recovery/pipeline.py
+++ b/python/src/data_platform_lab/recovery/pipeline.py
@@ -89,8 +89,10 @@ class RecoverableIngestionPipeline:
         )
 
         appended = False
+        raw_stored = False
         try:
             self._blob_store.put_bytes(raw_key, message.value)
+            raw_stored = True
             event = self._decode_event(message.value)
             schema, batch = self._arrow_batch(ingestion_id, message, event)
             self._iceberg_store.ensure_table(self._table_identifier, schema)
@@ -135,7 +137,7 @@ class RecoverableIngestionPipeline:
                     duration_seconds=(ended_at - started_at).total_seconds(),
                     rows_read=1,
                     rows_written=1 if appended else 0,
-                    files_processed=1 if self._blob_store.exists(raw_key) else 0,
+                    files_processed=1 if raw_stored else 0,
                     errors=[str(exc)],
                     extra={"raw_object_key": raw_key, "table": self._table_identifier},
                 )

--- a/python/tests/test_broker_kafka.py
+++ b/python/tests/test_broker_kafka.py
@@ -49,6 +49,7 @@ class FakeConsumer:
     def __init__(self, message: FakeMessage | None = None) -> None:
         self.message = message or FakeMessage()
         self.subscriptions: list[list[str]] = []
+        self.commits: list[tuple[list[Any], bool]] = []
         self.closed = False
 
     def subscribe(self, topics: list[str]) -> None:
@@ -56,6 +57,9 @@ class FakeConsumer:
 
     def poll(self, _timeout: float) -> FakeMessage:
         return self.message
+
+    def commit(self, *, offsets: list[Any], asynchronous: bool) -> None:
+        self.commits.append((offsets, asynchronous))
 
     def close(self) -> None:
         self.closed = True
@@ -72,6 +76,9 @@ def test_event_broker_contract_is_runtime_checkable() -> None:
             del topic, group_id, timeout_seconds
             return None
 
+        def acknowledge(self, message: BrokerMessage) -> None:
+            del message
+
         def close(self) -> None:
             return None
 
@@ -86,6 +93,27 @@ def test_kafka_adapter_validates_inputs_without_connecting() -> None:
 
     with pytest.raises(TypeError, match="bytes"):
         KafkaEventBroker.publish(broker, "events", "payload")  # type: ignore[arg-type]
+
+
+def test_kafka_acknowledgement_commits_next_offset() -> None:
+    class TopicPartition:
+        def __init__(self, topic: str, partition: int, offset: int) -> None:
+            self.topic = topic
+            self.partition = partition
+            self.offset = offset
+
+    broker = object.__new__(KafkaEventBroker)
+    consumer = FakeConsumer()
+    broker._consumer = consumer
+    broker._topic_partition_factory = TopicPartition
+
+    broker.acknowledge(BrokerMessage("events", 2, 7, b"key", b"payload"))
+
+    offsets, asynchronous = consumer.commits[0]
+    assert asynchronous is False
+    assert offsets[0].topic == "events"
+    assert offsets[0].partition == 2
+    assert offsets[0].offset == 8
 
 
 def test_broker_message_is_immutable_value_object() -> None:

--- a/python/tests/test_iceberg_store.py
+++ b/python/tests/test_iceberg_store.py
@@ -9,14 +9,32 @@ import pytest
 from data_platform_lab.iceberg import IcebergTableStore
 
 
+class FakeColumn:
+    def __init__(self, values: list[object]) -> None:
+        self._values = values
+
+    def to_pylist(self) -> list[object]:
+        return list(self._values)
+
+
 class FakeArrowTable:
-    def __init__(self, num_rows: int) -> None:
-        self.num_rows = num_rows
+    def __init__(self, appended: list[Any]) -> None:
+        self._appended = appended
+        self.num_rows = sum(int(getattr(payload, "num_rows", 0)) for payload in appended)
+
+    def column(self, field_name: str) -> FakeColumn:
+        values: list[object] = []
+        for payload in self._appended:
+            values.extend(getattr(payload, "values", {}).get(field_name, []))
+        if not values:
+            raise KeyError(field_name)
+        return FakeColumn(values)
 
 
 class FakePayload:
-    def __init__(self, num_rows: int) -> None:
+    def __init__(self, num_rows: int, values: dict[str, list[object]] | None = None) -> None:
         self.num_rows = num_rows
+        self.values = values or {}
 
 
 class FakeScan:
@@ -24,9 +42,7 @@ class FakeScan:
         self._appended = appended
 
     def to_arrow(self) -> FakeArrowTable:
-        return FakeArrowTable(
-            sum(int(getattr(payload, "num_rows", 0)) for payload in self._appended)
-        )
+        return FakeArrowTable(self._appended)
 
 
 class FakeTable:
@@ -36,7 +52,8 @@ class FakeTable:
     def append(self, table_data: Any) -> None:
         self.appended.append(table_data)
 
-    def scan(self) -> FakeScan:
+    def scan(self, selected_fields: tuple[str, ...] | None = None) -> FakeScan:
+        del selected_fields
         return FakeScan(self.appended)
 
 
@@ -89,6 +106,19 @@ def test_iceberg_store_append_and_scan_reflects_appended_rows() -> None:
 
     assert catalog.tables["analytics.events"].appended == [first, second]
     assert store.row_count("analytics.events") == 3
+
+
+def test_iceberg_store_reconciles_by_ingestion_id() -> None:
+    catalog = FakeCatalog()
+    store = IcebergTableStore(catalog)
+    store.ensure_table("analytics.events", object())
+    store.append(
+        "analytics.events",
+        FakePayload(1, {"ingestion_id": ["events:0:7"]}),
+    )
+
+    assert store.contains_value("analytics.events", "ingestion_id", "events:0:7")
+    assert not store.contains_value("analytics.events", "ingestion_id", "events:0:8")
 
 
 @pytest.mark.parametrize(

--- a/python/tests/test_recovery_pipeline.py
+++ b/python/tests/test_recovery_pipeline.py
@@ -1,0 +1,119 @@
+"""Tests for end-to-end recovery orchestration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from data_platform_lab.broker import BrokerMessage
+from data_platform_lab.observability import RunMetadata
+from data_platform_lab.recovery import RecoverableIngestionPipeline
+from data_platform_lab.storage import LocalBlobStore
+
+
+class FakeBroker:
+    def __init__(self) -> None:
+        self.acknowledged: list[BrokerMessage] = []
+
+    def acknowledge(self, message: BrokerMessage) -> None:
+        self.acknowledged.append(message)
+
+
+class FakeRunStore:
+    def __init__(self) -> None:
+        self.runs: dict[tuple[str, str], RunMetadata] = {}
+
+    def save(self, metadata: RunMetadata) -> None:
+        self.runs[(metadata.pipeline_name, metadata.run_id)] = metadata
+
+    def get(self, pipeline_name: str, run_id: str) -> RunMetadata | None:
+        return self.runs.get((pipeline_name, run_id))
+
+    def list_recent(self, limit: int = 20) -> list[RunMetadata]:
+        return list(self.runs.values())[-limit:]
+
+
+class FakeIcebergStore:
+    def __init__(self) -> None:
+        self.ingestion_ids: set[str] = set()
+        self.append_count = 0
+
+    def ensure_table(self, identifier: str, schema: Any) -> None:
+        del identifier, schema
+
+    def contains_value(self, identifier: str, field_name: str, value: object) -> bool:
+        del identifier
+        assert field_name == "ingestion_id"
+        return str(value) in self.ingestion_ids
+
+    def append(self, identifier: str, table_data: Any) -> None:
+        del identifier
+        ingestion_id = str(table_data.column("ingestion_id").to_pylist()[0])
+        self.ingestion_ids.add(ingestion_id)
+        self.append_count += 1
+
+
+def _message() -> BrokerMessage:
+    payload = json.dumps(
+        {
+            "sensor_id": "sensor-1",
+            "type": "temperature",
+            "value": 21.5,
+            "unit": "C",
+            "location": "lab",
+            "timestamp": "2026-09-01T12:00:00+00:00",
+        }
+    ).encode()
+    return BrokerMessage("sensor-events", 0, 7, b"sensor-1", payload)
+
+
+def _pipeline(tmp_path: Path) -> tuple[RecoverableIngestionPipeline, FakeBroker, FakeRunStore, FakeIcebergStore]:
+    broker = FakeBroker()
+    run_store = FakeRunStore()
+    iceberg_store = FakeIcebergStore()
+    pipeline = RecoverableIngestionPipeline(
+        broker=broker,  # type: ignore[arg-type]
+        run_store=run_store,
+        blob_store=LocalBlobStore(tmp_path),
+        iceberg_store=iceberg_store,  # type: ignore[arg-type]
+    )
+    return pipeline, broker, run_store, iceberg_store
+
+
+def test_recovery_pipeline_acknowledges_after_durable_success(tmp_path: Path) -> None:
+    pipeline, broker, run_store, iceberg_store = _pipeline(tmp_path)
+    message = _message()
+
+    result = pipeline.process(message)
+
+    assert result.ingestion_id == "sensor-events:0:7"
+    assert result.appended is True
+    assert iceberg_store.append_count == 1
+    assert broker.acknowledged == [message]
+    assert run_store.get("broker_to_iceberg", result.ingestion_id).status == "success"  # type: ignore[union-attr]
+    assert (tmp_path / result.raw_object_key).read_bytes() == message.value
+
+
+def test_replay_after_iceberg_commit_does_not_duplicate(tmp_path: Path) -> None:
+    pipeline, broker, run_store, iceberg_store = _pipeline(tmp_path)
+    message = _message()
+
+    with pytest.raises(RuntimeError, match="injected failure"):
+        pipeline.process(message, fail_after_iceberg=True)
+
+    assert iceberg_store.append_count == 1
+    assert broker.acknowledged == []
+    failed = run_store.get("broker_to_iceberg", "sensor-events:0:7")
+    assert failed is not None and failed.status == "failed"
+
+    result = pipeline.process(message)
+
+    assert result.replayed is True
+    assert result.appended is False
+    assert iceberg_store.append_count == 1
+    assert broker.acknowledged == [message]
+    recovered = run_store.get("broker_to_iceberg", "sensor-events:0:7")
+    assert recovered is not None and recovered.status == "success"

--- a/python/tests/test_recovery_pipeline.py
+++ b/python/tests/test_recovery_pipeline.py
@@ -70,7 +70,9 @@ def _message() -> BrokerMessage:
     return BrokerMessage("sensor-events", 0, 7, b"sensor-1", payload)
 
 
-def _pipeline(tmp_path: Path) -> tuple[RecoverableIngestionPipeline, FakeBroker, FakeRunStore, FakeIcebergStore]:
+def _pipeline(
+    tmp_path: Path,
+) -> tuple[RecoverableIngestionPipeline, FakeBroker, FakeRunStore, FakeIcebergStore]:
     broker = FakeBroker()
     run_store = FakeRunStore()
     iceberg_store = FakeIcebergStore()


### PR DESCRIPTION
## Summary

Completes Milestone 3 Phase 6 with an explicit failure/recovery path across Kafka, PostgreSQL, Garage S3 and Iceberg.

- extends `EventBroker` with explicit post-processing acknowledgement
- commits Kafka `offset + 1` synchronously only after durable processing succeeds
- adds deterministic ingestion IDs from `(topic, partition, offset)`
- persists raw broker bytes under deterministic Garage object keys
- writes the same ingestion ID into Iceberg for replay reconciliation
- adds a recoverable broker-to-Iceberg coordinator using the existing platform boundaries
- adds an injected failure after the Iceberg commit and before final metadata/Kafka acknowledgement
- proves replay of that unacknowledged position does not append a duplicate analytical row
- adds `data-platform-lab recovery` and a four-service `Platform Recovery` integration workflow
- documents the at-least-once + deterministic reconciliation semantics and adds architecture/sequence diagrams

## Recovery order

```text
consume
  -> PostgreSQL running metadata
  -> deterministic Garage raw object
  -> Iceberg append-if-ingestion-id-missing
  -> PostgreSQL success metadata
  -> Kafka offset acknowledgement
```

Kafka acknowledgement is intentionally last. On a crash after Iceberg commit but before acknowledgement, the same broker position is replayed. The raw object overwrites the same key, the run reuses the same ID, and the Iceberg ingestion ID is reconciled before append.

## Semantics

This is an at-least-once broker delivery model with deterministic reconciliation. It does not claim a distributed exactly-once transaction across Kafka, PostgreSQL, S3 and Iceberg.

The Iceberg reconciliation scan is deliberately simple for this local lab; production-scale systems would replace it with an ingestion ledger, merge/upsert strategy, or engine-native transactional mechanism.

## Validation

Unit tests cover Kafka offset acknowledgement and post-Iceberg replay without duplication. The dedicated `Platform Recovery` workflow boots Kafka, PostgreSQL and Garage, uses the PostgreSQL-backed PyIceberg catalog, injects the post-Iceberg failure, reconsumes the same uncommitted position, verifies a final Iceberg row count of one, verifies successful run metadata and the raw Garage object, and only then commits Kafka.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an explicit failure/recovery path for broker-to-Iceberg ingestion so an unacknowledged Kafka message can be replayed without duplicating analytical rows. Kafka offsets are no longer committed implicitly; they are acknowledged only after durable processing succeeds, and custom `EventBroker` adapters must implement the new `acknowledge` method.

**Recovery flow**
- Kafka acknowledgement is the last step, so a crash before it leaves the position eligible for replay.
- The `(topic, partition, offset)` identity is reused as the PostgreSQL `run_id`, the Garage object key, and the Iceberg `ingestion_id`.
- On replay, an existing `ingestion_id` skips the Iceberg append, keeping the final row count at one.

**Validation**
- Adds `data-platform-lab recovery`, a smoke command that publishes a message, injects a failure after the Iceberg commit, and replays the same position.
- Adds a `Platform Recovery` workflow that boots Kafka, PostgreSQL, and Garage and runs the smoke command.
- This is at-least-once delivery with deterministic reconciliation, not a distributed exactly-once transaction.

<sup>Written for commit 2c593e61ac9451f394f9dc56bb305f50f22d6d25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DiogoRibeiro7/data-platform-lab/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

